### PR TITLE
Calling stlink_reset() causes the target to reset after disconnecting.

### DIFF
--- a/flash/main.c
+++ b/flash/main.c
@@ -120,13 +120,13 @@ int main(int ac, char** av)
 
   if (o.devname != NULL) /* stlinkv1 */
   {
-    sl = stlink_v1_open(50, 1);
+    sl = stlink_v1_open(50, o.reset);
     if (sl == NULL) goto on_error;
     sl->verbose = 50;
   }
   else /* stlinkv2 */
   {
-    sl = stlink_open_usb(50, 1);
+    sl = stlink_open_usb(50, o.reset);
     if (sl == NULL) goto on_error;
     sl->verbose = 50;
   }
@@ -136,9 +136,6 @@ int main(int ac, char** av)
 
   if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE)
     stlink_enter_swd_mode(sl);
-
-  if (o.reset)
-    stlink_reset(sl);
 
 // Disable DMA - Set All DMA CCR Registers to zero. - AKS 1/7/2013
   if (sl->chip_id == STM32_CHIPID_F4)

--- a/flash/main.c
+++ b/flash/main.c
@@ -120,15 +120,21 @@ int main(int ac, char** av)
 
   if (o.devname != NULL) /* stlinkv1 */
   {
-    sl = stlink_v1_open(50, o.reset);
+    sl = stlink_v1_open(50, 0);
     if (sl == NULL) goto on_error;
     sl->verbose = 50;
   }
   else /* stlinkv2 */
   {
-    sl = stlink_open_usb(50, o.reset);
+    sl = stlink_open_usb(50, 0);
     if (sl == NULL) goto on_error;
     sl->verbose = 50;
+  }
+
+  if (o.addr >= sl->flash_base && o.addr + o.size <= sl->flash_base + sl->flash_size)
+  {
+    // Our address is inside flash memory so we need to reset the stlink.
+    stlink_reset(sl);
   }
 
   if (stlink_current_mode(sl) == STLINK_DEV_DFU_MODE)
@@ -136,6 +142,9 @@ int main(int ac, char** av)
 
   if (stlink_current_mode(sl) != STLINK_DEV_DEBUG_MODE)
     stlink_enter_swd_mode(sl);
+
+  if (o.reset)
+    stlink_reset(sl);
 
 // Disable DMA - Set All DMA CCR Registers to zero. - AKS 1/7/2013
   if (sl->chip_id == STM32_CHIPID_F4)


### PR DESCRIPTION
While trying to read/write directly from/to RAM i noticed that the STM32 would always reset after stmlink disconnects.
This is not a good thing when using stlink to access RAM on running programs.

Unfortunately writing to Flash fails if this reset does not occur.

My hardware is STM32VLDISCOVER where this change works as intended
however i am not able to verify this patch on other platforms.