### PR TITLE
STM32F42xx memory map issues

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -315,6 +315,29 @@ static const char* const memory_map_template_F4 =
     "  <memory type=\"rom\" start=\"0x1fffc000\" length=\"0x10\"/>"         // option byte area
     "</memory-map>";
 
+static const char* const memory_map_template_F4_HD =
+    "<?xml version=\"1.0\"?>"
+    "<!DOCTYPE memory-map PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
+    "     \"http://sourceware.org/gdb/gdb-memory-map.dtd\">"
+    "<memory-map>"
+    "  <memory type=\"rom\" start=\"0x00000000\" length=\"0x100000\"/>"     // code = sram, bootrom or flash; flash is bigger
+    "  <memory type=\"ram\" start=\"0x10000000\" length=\"0x10000\"/>"      // ccm ram
+    "  <memory type=\"ram\" start=\"0x20000000\" length=\"0x30000\"/>"      // sram
+    "  <memory type=\"flash\" start=\"0x08000000\" length=\"0x10000\">"     //Sectors 0..3
+    "    <property name=\"blocksize\">0x4000</property>"                    //16kB
+    "  </memory>"
+    "  <memory type=\"flash\" start=\"0x08010000\" length=\"0x10000\">"     //Sector 4
+    "    <property name=\"blocksize\">0x10000</property>"                   //64kB
+    "  </memory>"
+    "  <memory type=\"flash\" start=\"0x08020000\" length=\"0xE0000\">"     //Sectors 5..11
+    "    <property name=\"blocksize\">0x20000</property>"                   //128kB
+    "  </memory>"
+    "  <memory type=\"ram\" start=\"0x40000000\" length=\"0x1fffffff\"/>"   // peripheral regs
+    "  <memory type=\"ram\" start=\"0xe0000000\" length=\"0x1fffffff\"/>"   // cortex regs
+    "  <memory type=\"rom\" start=\"0x1fff0000\" length=\"0x7800\"/>"       // bootrom
+    "  <memory type=\"rom\" start=\"0x1fffc000\" length=\"0x10\"/>"         // option byte area
+    "</memory-map>";
+
 static const char* const memory_map_template =
     "<?xml version=\"1.0\"?>"
     "<!DOCTYPE memory-map PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
@@ -336,8 +359,10 @@ char* make_memory_map(stlink_t *sl) {
     char* map = malloc(4096);
     map[0] = '\0';
 
-    if(sl->chip_id==STM32_CHIPID_F4 || sl->chip_id==STM32_CHIPID_F4_HD) {
+    if(sl->chip_id==STM32_CHIPID_F4) {
         strcpy(map, memory_map_template_F4);
+    } else if(sl->chip_id==STM32_CHIPID_F4_HD) {
+        strcpy(map, memory_map_template_F4_HD);
     } else {
         snprintf(map, 4096, memory_map_template,
                 sl->flash_size,

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -209,7 +209,7 @@ extern "C" {
             .description = "F42x and F43x device",
             .flash_size_reg = 0x1FFF7A22,  /* As in rm0090 since Rev 2*/
             .flash_pagesize = 0x4000,
-            .sram_size = 0x30000,
+            .sram_size = 0x40000,
             .bootrom_base = 0x1fff0000,
             .bootrom_size = 0x7800
         },


### PR DESCRIPTION
STM32_CHIPID_F4_HD (as on STM32F429I-Discovery board) has more RAM than STM32_CHIPID_F4; we need to distinguish the two so that the debugger can see the top third of RAM on the STM32F429I-Discovery.

See [Issue 287](https://github.com/texane/stlink/issues/287).