### PR TITLE
Minor error reporting tweaks and redundant  includes removal

### DIFF
--- a/src/stlink-sg.c
+++ b/src/stlink-sg.c
@@ -1017,10 +1017,9 @@ stlink_t* stlink_v1_open_inner(const int verbose) {
 
 stlink_t* stlink_v1_open(const int verbose, int reset) {
     stlink_t *sl = stlink_v1_open_inner(verbose);
-    if (sl == NULL) {
-        fputs("Error: could not open stlink device\n", stderr);
+    if (sl == NULL)
         return NULL;
-    }
+
     // by now, it _must_ be fully open and in a useful mode....
     stlink_enter_swd_mode(sl);
     /* Now we are ready to read the parameters  */

--- a/src/stlink-sg.c
+++ b/src/stlink-sg.c
@@ -980,7 +980,7 @@ stlink_t* stlink_v1_open_inner(const int verbose) {
     ugly_init(verbose);
     stlink_t *sl = stlink_open(verbose);
     if (sl == NULL) {
-        fputs("Error: could not open stlink device\n", stderr);
+        ELOG("Could not open stlink device\n");
         return NULL;
     }
 

--- a/src/stlink-sg.c
+++ b/src/stlink-sg.c
@@ -79,13 +79,8 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdarg.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <fcntl.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include "mmap.h"
 
 #include "stlink-common.h"
 #include "stlink-sg.h"


### PR DESCRIPTION
Hi,
I've faced multiple error messages while still using compiled tools successfully. This was confusing. Those errors were thrown to stderr twice by stlinkv1 specific functions while stlinkv2 was used. I've removed duplicated error message and replaced the other one with logging macro for consistency with the rest of logs in this file. If additional device opening error needs to be thrown I think it's up to 'stlink_v1_open' and 'stlink_open_usb' callers to log it if both calls fail.

Just letting you know if you're interested.

Regards.