### PR TITLE
Properly close socket on WIN32 to allow accepting further connections

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -733,6 +733,9 @@ int serve(stlink_t *sl, st_state_t *st) {
         int status = gdb_recv_packet(client, &packet);
         if(status < 0) {
             ELOG("cannot recv: %d\n", status);
+#ifdef __MINGW32__
+            win32_close_socket(sock);
+#endif
             return 1;
         }
 
@@ -942,6 +945,9 @@ int serve(stlink_t *sl, st_state_t *st) {
                     int status = gdb_check_for_interrupt(client);
                     if(status < 0) {
                         ELOG("cannot check for int: %d\n", status);
+#ifdef __MINGW32__
+                        win32_close_socket(sock);
+#endif
                         return 1;
                     }
 
@@ -1256,6 +1262,9 @@ int serve(stlink_t *sl, st_state_t *st) {
                 ELOG("cannot send: %d\n", result);
                 free(reply);
                 free(packet);
+#ifdef __MINGW32__
+                win32_close_socket(sock);
+#endif
                 return 1;
             }
 
@@ -1264,6 +1273,10 @@ int serve(stlink_t *sl, st_state_t *st) {
 
         free(packet);
     }
+
+#ifdef __MINGW32__
+    win32_close_socket(sock);
+#endif
 
     return 0;
 }

--- a/mingw/mingw.c
+++ b/mingw/mingw.c
@@ -163,13 +163,15 @@ win32_shutdown(SOCKET fd, int mode)
     }
     return rc;
 }
-int win32_close_socket(SOCKET fd) {
-    int rc;
 
-    rc = closesocket(fd);
+int win32_close_socket(SOCKET fd)
+{
+    int rc = closesocket(fd);
+    if(rc == SOCKET_ERROR) {
+        set_socket_errno(WSAGetLastError());
+    }
     return rc;
 }
-
 
 ssize_t win32_write_socket(SOCKET fd, void *buf, int n)
 {

--- a/mingw/mingw.h
+++ b/mingw/mingw.h
@@ -54,6 +54,7 @@ SOCKET  win32_socket(int, int, int);
 int     win32_connect(SOCKET, struct sockaddr*, socklen_t);
 SOCKET  win32_accept(SOCKET, struct sockaddr*, socklen_t *);
 int     win32_shutdown(SOCKET, int);
+int 	win32_close_socket(SOCKET fd);
 
 #define strtok_r(x, y, z)      win32_strtok_r(x, y, z)
 #define strsep(x,y) win32_strsep(x,y)


### PR DESCRIPTION
On Windows after GDB disconnect:

2015-03-15T18:06:19 INFO gdbserver/gdb-server.c: Listening at *:4242...
2015-03-15T18:06:37 INFO gdbserver/gdb-server.c: GDB connected.
2015-03-15T18:06:47 ERROR gdbserver/gdb-server.c: cannot recv: -2
2015-03-15T18:06:47 INFO gdbserver/gdb-server.c: Listening at *:4242...

We cannot connect again cause our first forgotten socket is still listening the port.