### PR TITLE
Updated the memory map for stm32f42xxx and stm32f43xxx devices.

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -325,7 +325,11 @@ static const char* const memory_map_template_F4_HD =
     "<memory-map>"
     "  <memory type=\"rom\" start=\"0x00000000\" length=\"0x100000\"/>"     // code = sram, bootrom or flash; flash is bigger
     "  <memory type=\"ram\" start=\"0x10000000\" length=\"0x10000\"/>"      // ccm ram
-    "  <memory type=\"ram\" start=\"0x20000000\" length=\"0x30000\"/>"      // sram
+    "  <memory type=\"ram\" start=\"0x20000000\" length=\"0x40000\"/>"      // sram
+    "  <memory type=\"ram\" start=\"0x60000000\" length=\"0x10000000\"/>"   // fmc bank 1 (nor/psram/sram)
+    "  <memory type=\"ram\" start=\"0x70000000\" length=\"0x20000000\"/>"   // fmc bank 2 & 3 (nand flash)
+    "  <memory type=\"ram\" start=\"0x90000000\" length=\"0x10000000\"/>"   // fmc bank 4 (pc card)
+    "  <memory type=\"ram\" start=\"0xC0000000\" length=\"0x20000000\"/>"   // fmc sdram bank 1 & 2
     "  <memory type=\"flash\" start=\"0x08000000\" length=\"0x10000\">"     //Sectors 0..3
     "    <property name=\"blocksize\">0x4000</property>"                    //16kB
     "  </memory>"


### PR DESCRIPTION
The length field for internal sram size looks to be incorrect - it should be 256K. The stm32f429xxx/439xxx literature says "up to 256K" but I cant find an active chip in that range that has anything other than 256K [link](http://www.st.com/web/en/catalog/mmc/FM141/SC1169/SS1577/LN1806?ecmp=stm32f429-439_pron_pr-ces2014_nov2013&sc=stm32f429-439-pr).

Also added the FMC memory map according to the [reference manual](http://www.st.com/stonline/stappl/resourceSelector/app?page=fullResourceSelector&doctype=reference_manual&LineID=1806) (page 1586), and I can now access external memory from within GDB. Admittedly, I've only tested the SDRAM since my board doesnt have any of the others.