### PR TITLE
STM32F4 8-bit support for 1.8v operation

### DIFF
--- a/flashloaders/stm32f4lv.s
+++ b/flashloaders/stm32f4lv.s
@@ -1,0 +1,33 @@
+.global start
+.syntax unified
+
+@ r0 = source
+@ r1 = target
+@ r2 = wordcount
+@ r3 = flash_base
+@ r4 = temp
+
+start:
+    lsls    r2, r2, #2
+    ldr     r3, flash_base
+next:
+    cbz     r2, done
+    ldrb    r4, [r0]
+    strb    r4, [r1]
+
+wait:
+    ldrh    r4, [r3, #0x0e]
+    tst.w   r4, #1
+    bne     wait
+
+    add     r0, #1
+    add     r1, #1
+    sub     r2, #1
+    b       next
+done:
+    bkpt
+
+.align 2
+
+flash_base:
+	.word 0x40023c00


### PR DESCRIPTION
Per ST doc DM00035129.pdf "DocID022063 Rev 5", the STM32F415xx data sheet,
table 40 on page 110 of the PDF, 32-bit program operation is only possible
above 2.7 Volts.

In order to support programming on devices running at lower voltages, this
commit adds an 8-bit programming mode and the necessary tests to enable it
when the reported voltage is below 2.7 Volts.