### PR TITLE
STM32F446 support

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -388,7 +388,7 @@ char* make_memory_map(stlink_t *sl) {
     char* map = malloc(4096);
     map[0] = '\0';
 
-    if(sl->chip_id==STM32_CHIPID_F4) {
+    if(sl->chip_id==STM32_CHIPID_F4 || sl->chip_id==STM32_CHIPID_F446) {
         strcpy(map, memory_map_template_F4);
     } else if(sl->chip_id==STM32_CHIPID_F4_HD) {
         strcpy(map, memory_map_template_F4_HD);

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -153,7 +153,8 @@ static inline uint32_t read_flash_obr(stlink_t *sl) {
 static inline uint32_t read_flash_cr(stlink_t *sl) {
     uint32_t res;
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) ||(sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE))
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446))
         res = stlink_read_debug32(sl, FLASH_F4_CR);
     else
         res = stlink_read_debug32(sl, FLASH_CR);
@@ -166,7 +167,8 @@ static inline uint32_t read_flash_cr(stlink_t *sl) {
 static inline unsigned int is_flash_locked(stlink_t *sl) {
     /* return non zero for true */
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) )
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446))
         return read_flash_cr(sl) & (1 << FLASH_F4_CR_LOCK);
     else
         return read_flash_cr(sl) & (1 << FLASH_CR_LOCK);
@@ -179,7 +181,8 @@ static void unlock_flash(stlink_t *sl) {
        the FPEC block until next reset.
        */
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE)) {
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)) {
         stlink_write_debug32(sl, FLASH_F4_KEYR, FLASH_KEY1);
         stlink_write_debug32(sl, FLASH_F4_KEYR, FLASH_KEY2);
     } else {
@@ -205,7 +208,8 @@ static int unlock_flash_if(stlink_t *sl) {
 
 static void lock_flash(stlink_t *sl) {
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE)) {
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)) {
         const uint32_t n = read_flash_cr(sl) | (1 << FLASH_F4_CR_LOCK);
         stlink_write_debug32(sl, FLASH_F4_CR, n);
     } else {
@@ -218,7 +222,8 @@ static void lock_flash(stlink_t *sl) {
 
 static void set_flash_cr_pg(stlink_t *sl) {
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE)) {
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)) {
         uint32_t x = read_flash_cr(sl);
         x |= (1 << FLASH_CR_PG);
         stlink_write_debug32(sl, FLASH_F4_CR, x);
@@ -231,7 +236,8 @@ static void set_flash_cr_pg(stlink_t *sl) {
 static void __attribute__((unused)) clear_flash_cr_pg(stlink_t *sl) {
     const uint32_t n = read_flash_cr(sl) & ~(1 << FLASH_CR_PG);
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE))
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446))
         stlink_write_debug32(sl, FLASH_F4_CR, n);
     else
         stlink_write_debug32(sl, FLASH_CR, n);
@@ -249,7 +255,8 @@ static void __attribute__((unused)) clear_flash_cr_per(stlink_t *sl) {
 
 static void set_flash_cr_mer(stlink_t *sl) {
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE))
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446))
         stlink_write_debug32(sl, FLASH_F4_CR,
                 stlink_read_debug32(sl, FLASH_F4_CR) | (1 << FLASH_CR_MER));
     else
@@ -259,7 +266,8 @@ static void set_flash_cr_mer(stlink_t *sl) {
 
 static void __attribute__((unused)) clear_flash_cr_mer(stlink_t *sl) {
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE))
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446))
         stlink_write_debug32(sl, FLASH_F4_CR,
                 stlink_read_debug32(sl, FLASH_F4_CR) & ~(1 << FLASH_CR_MER));
     else
@@ -269,7 +277,8 @@ static void __attribute__((unused)) clear_flash_cr_mer(stlink_t *sl) {
 
 static void set_flash_cr_strt(stlink_t *sl) {
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE)) {
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)) {
         uint32_t x = read_flash_cr(sl);
         x |= (1 << FLASH_F4_CR_STRT);
         stlink_write_debug32(sl, FLASH_F4_CR, x);
@@ -286,7 +295,8 @@ static inline uint32_t read_flash_acr(stlink_t *sl) {
 static inline uint32_t read_flash_sr(stlink_t *sl) {
     uint32_t res;
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE))
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446))
         res = stlink_read_debug32(sl, FLASH_F4_SR);
     else
         res = stlink_read_debug32(sl, FLASH_SR);
@@ -296,7 +306,8 @@ static inline uint32_t read_flash_sr(stlink_t *sl) {
 
 static inline unsigned int is_flash_busy(stlink_t *sl) {
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE))
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446))
         return read_flash_sr(sl) & (1 << FLASH_F4_SR_BSY);
     else
         return read_flash_sr(sl) & (1 << FLASH_SR_BSY);
@@ -1027,7 +1038,8 @@ uint32_t calculate_F4_sectornum(uint32_t flashaddr){
 
 uint32_t stlink_calculate_pagesize(stlink_t *sl, uint32_t flashaddr){
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE)) {
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)) {
         uint32_t sector=calculate_F4_sectornum(flashaddr);
         if (sector>= 12) {
             sector -= 12;
@@ -1048,7 +1060,8 @@ uint32_t stlink_calculate_pagesize(stlink_t *sl, uint32_t flashaddr){
 int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 {
     if ((sl->chip_id == STM32_CHIPID_F2) || (sl->chip_id == STM32_CHIPID_F4) ||  (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE)) {
+            (sl->chip_id == STM32_CHIPID_F4_LP) || (sl->chip_id == STM32_CHIPID_F4_HD) || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)) {
         /* wait for ongoing op to finish */
         wait_flash_busy(sl);
 
@@ -1414,7 +1427,8 @@ int write_loader_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* size) {
         loader_code = loader_code_stm32vl;
         loader_size = sizeof(loader_code_stm32vl);
     } else if (sl->chip_id == STM32_CHIPID_F2 || sl->chip_id == STM32_CHIPID_F4 || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            sl->chip_id == STM32_CHIPID_F4_LP || sl->chip_id == STM32_CHIPID_F4_HD || (sl->chip_id == STM32_CHIPID_F411RE)){
+            sl->chip_id == STM32_CHIPID_F4_LP || sl->chip_id == STM32_CHIPID_F4_HD || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)){
         int voltage = stlink_target_voltage(sl);
         if (voltage > 2700) {
             loader_code = loader_code_stm32f4;
@@ -1603,7 +1617,8 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         (sl->chip_id == STM32_CHIPID_F4_DE) ||
         (sl->chip_id == STM32_CHIPID_F4_LP) ||
         (sl->chip_id == STM32_CHIPID_F4_HD) ||
-        (sl->chip_id == STM32_CHIPID_F411RE)) {
+        (sl->chip_id == STM32_CHIPID_F411RE) ||
+        (sl->chip_id == STM32_CHIPID_F446)) {
         /* todo: check write operation */
 
         ILOG("Starting Flash write for F2/F4\n");
@@ -1852,7 +1867,8 @@ int run_flash_loader(stlink_t *sl, flash_loader_t* fl, stm32_addr_t target, cons
         stlink_write_reg(sl, fl->loader_addr, 15); /* pc register */
 
     } else if (sl->chip_id == STM32_CHIPID_F2 || sl->chip_id == STM32_CHIPID_F4 || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            sl->chip_id == STM32_CHIPID_F4_LP || sl->chip_id == STM32_CHIPID_F4_HD || (sl->chip_id == STM32_CHIPID_F411RE)) {
+            sl->chip_id == STM32_CHIPID_F4_LP || sl->chip_id == STM32_CHIPID_F4_HD || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)) {
 
         size_t count = size / sizeof(uint32_t);
         if (size % sizeof(uint32_t)) ++count;
@@ -1912,7 +1928,8 @@ int run_flash_loader(stlink_t *sl, flash_loader_t* fl, stm32_addr_t target, cons
         }
 
     } else if (sl->chip_id == STM32_CHIPID_F2 || sl->chip_id == STM32_CHIPID_F4 || (sl->chip_id == STM32_CHIPID_F4_DE) ||
-            sl->chip_id == STM32_CHIPID_F4_LP || sl->chip_id == STM32_CHIPID_F4_HD || (sl->chip_id == STM32_CHIPID_F411RE)) {
+            sl->chip_id == STM32_CHIPID_F4_LP || sl->chip_id == STM32_CHIPID_F4_HD || (sl->chip_id == STM32_CHIPID_F411RE) ||
+            (sl->chip_id == STM32_CHIPID_F446)) {
 
         stlink_read_reg(sl, 2, &rr);
         if (rr.r[2] != 0) {

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -110,6 +110,7 @@ extern "C" {
 #define STM32_CHIPID_F4_HD          0x419
 #define STM32_CHIPID_F1_VL_MEDIUM_LOW 0x420
 
+#define STM32_CHIPID_F446           0x421
 #define STM32_CHIPID_F3             0x422
 #define STM32_CHIPID_F4_LP          0x423
 
@@ -318,6 +319,16 @@ extern "C" {
             .sram_size = 0x2000,//0x1000 for low density devices
             .bootrom_base = 0x1ffff000,
             .bootrom_size = 0x800
+        },
+        {
+            // STM32F446x family. Support based on DM00135183.pdf (RM0390) document.
+            .chip_id = STM32_CHIPID_F446,
+            .description = "F446 device",
+            .flash_size_reg = 0x1fff7a22,
+            .flash_pagesize = 0x20000,
+            .sram_size = 0x20000,
+            .bootrom_base = 0x1fff0000,
+            .bootrom_size = 0x7800
         },
         {
             // This is STK32F303VCT6 device from STM32 F3 Discovery board.


### PR DESCRIPTION
This PR adds support for STM32F446x family.

Flashing and debugging has been tested with custom hardware with ST-Link v2 over SWD, and it generally works OK.