### PR TITLE
Make _stlink_usb_reset use hardreset

### DIFF
--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -68,6 +68,7 @@ extern "C" {
 #define STLINK_DEBUG_WRITEDEBUGREG	0x0f
 #define STLINK_DEBUG_ENTER_SWD		0xa3
 #define STLINK_DEBUG_ENTER_JTAG	0x00
+#define STLINK_DEBUG_HARDRESET   	0x3c
 
     // TODO - possible poor names...
 #define STLINK_SWD_ENTER 0x30

--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -413,7 +413,8 @@ void _stlink_usb_reset(stlink_t * sl) {
     int i = fill_command(sl, SG_DXFER_FROM_DEV, rep_len);
 
     cmd[i++] = STLINK_DEBUG_COMMAND;
-    cmd[i++] = STLINK_DEBUG_RESETSYS;
+    cmd[i++] = STLINK_DEBUG_HARDRESET;
+    cmd[i++] = 0x2;
 
     size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
     if (size == -1) {


### PR DESCRIPTION
This change makes my board, STM32F7 Discovery actually reset

(final patch for today :) )