### PR TITLE
segmentation fault length fix

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -654,10 +654,12 @@ static int flash_go(stlink_t *sl) {
             stlink_calculate_pagesize(sl, page);
 
             DLOG("flash_do: page %08x\n", page);
-
+            unsigned send = length > FLASH_PAGE ? FLASH_PAGE : length;
             if(stlink_write_flash(sl, page, fb->data + (page - fb->addr),
-                        length > FLASH_PAGE ? FLASH_PAGE : length) < 0)
+                        send) < 0)
                 goto error;
+            length -= send;
+            
         }
     }
 


### PR DESCRIPTION
I was getting a segmentation fault error when programming a particularly large image into my Nucleo Board. I found this small passage of code that looks like is missing a variable update. After this change I've been able to program my board without getting the segmentation fault. My program runs fine, so the fix looks alright to me.