### PR TITLE
Added parameter to specify one stlink v2 of many

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -173,7 +173,7 @@ int main(int argc, char** argv) {
     parse_options(argc, argv, &state);
     switch (state.stlink_version) {
         case 2:
-            sl = stlink_open_usb(state.logging_level, 0);
+	        sl = stlink_open_usb(state.logging_level, 0, NULL);
             if(sl == NULL) return 1;
             break;
         case 1:

--- a/gui/stlink-gui.c
+++ b/gui/stlink-gui.c
@@ -530,7 +530,7 @@ connect_button_cb (GtkWidget *widget, gpointer data)
     /* try version 1 then version 2 */
     gui->sl = stlink_v1_open(0, 1);
     if (gui->sl == NULL) {
-        gui->sl = stlink_open_usb(0, 1);
+	    gui->sl = stlink_open_usb(0, 1, NULL);
     }
     if (gui->sl == NULL) {
         stlink_gui_set_info_error_message (gui, "Failed to connect to STLink.");		return;

--- a/src/st-info.c
+++ b/src/st-info.c
@@ -51,7 +51,7 @@ stlink_t* open_sl(void)
     stlink_t* sl;
     sl = stlink_v1_open(0, 1);
     if (sl == NULL)
-        sl = stlink_open_usb(0, 1);
+	    sl = stlink_open_usb(0, 1, NULL);
     return sl;
 }
 

--- a/src/st-term.c
+++ b/src/st-term.c
@@ -251,7 +251,7 @@ int main(int ac, char** av) {
 
     sig_init();
 
-    sl = stlink_open_usb(10, 1);
+    sl = stlink_open_usb(10, 1, NULL);
     if (sl != NULL) {
         printf("ST-Linky proof-of-concept terminal :: Created by Necromant for lulz\n");
         stlink_version(sl);

--- a/src/stlink-usb.h
+++ b/src/stlink-usb.h
@@ -30,7 +30,7 @@ extern "C" {
         unsigned int cmd_len;
     };
 
-    stlink_t* stlink_open_usb(const int verbose, int reset);
+    stlink_t* stlink_open_usb(const int verbose, int reset, char *p_usb_iserial);
 
 
 #ifdef	__cplusplus

--- a/src/test_usb.c
+++ b/src/test_usb.c
@@ -10,7 +10,7 @@ int main(int ac, char** av) {
     ac = ac;
     av = av;
 
-    sl = stlink_open_usb(10, 1);
+    sl = stlink_open_usb(10, 1, NULL);
     if (sl != NULL) {
         printf("-- version\n");
         stlink_version(sl);


### PR DESCRIPTION
This adds a parameter to the function stlink_open_usb and to the binary
st-flash to specify one of multiple connected stlinks.
As the identifier the iSerial of the stlink is used.
If no serial is given the function and binary behave as before.