### PR TITLE
Added STM32L053R8

### DIFF
--- a/README
+++ b/README
@@ -200,6 +200,7 @@ Known Working Targets:
 * STM32F303RET6 (STM32 Nucleo-F303RE board)
 * STM32F334R8 (STM32 Nucleo-F334R8 board)
 * STM32F411RET6 (STM32 Nucleo-F411RE board)
-& STM32F756NGHx (STMF7 evaluation board)
+* STM32F756NGHx (STMF7 evaluation board)
+* STM32L053R8 (STM32 Nucleo-L053R8 board)
 
 Please report any and all known working combinations so I can update this!


### PR DESCRIPTION
Hello, checked this board with stink. It communicates without flaw with the board:

```
2015-12-15T14:47:03 INFO src/stlink-common.c: Loading device parameters....
2015-12-15T14:47:03 INFO src/stlink-common.c: Device connected is: L0x3 device, id 0x10086417
2015-12-15T14:47:03 INFO src/stlink-common.c: SRAM size: 0x2000 bytes (8 KiB), Flash: 0x10000 bytes (64 KiB) in pages of 128 bytes
2015-12-15T14:47:03 INFO gdbserver/gdb-server.c: Chip ID is 00000417, Core ID is  0bc11477.
2015-12-15T14:47:03 INFO gdbserver/gdb-server.c: Target voltage is 3264 mV.
2015-12-15T14:47:03 INFO gdbserver/gdb-server.c: Listening at *:4242...
```

When I launch GDB and connect to the server, I get (updated with curent version of stink) :

```
2015-12-15T15:59:05 INFO gdbserver/gdb-server.c: Found 4 hw breakpoint registers
2015-12-15T15:59:05 INFO gdbserver/gdb-server.c: GDB connected.
```

on the st-util side and :

```
Cannot access memory at address 0xffffffff
```

on the GDB side

Reading and writing to memory and registers works however I get 

```
Cannot access memory at address 0xffffffff
```

Each time I write to the memory or to a register