### PR TITLE
Allow flashing of STM32L4 down to 1.71 V

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -1818,7 +1818,7 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         } else {
             /* L4 does not have a byte-write mode */
             int voltage = stlink_target_voltage(sl);
-            if (voltage <= 2700) {
+            if (voltage < 1710) {
                 printf("Target voltage (%d mV) too low for flash writes!\n", voltage);
                 return -1;
             }


### PR DESCRIPTION
The STM32L4 specification specifies that VDD can be 1.71 - 3.6 V.

Signed-off-by: Greg Meiste <w30289@motorola.com>