### PR TITLE
Fix issue where "unknown chip id!" is seen every other time

### DIFF
--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -6,6 +6,7 @@
 #include <sys/types.h>
 #include <libusb.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "stlink-common.h"
 #include "stlink-usb.h"
@@ -879,6 +880,7 @@ stlink_t* stlink_open_usb(const int verbose, int reset, char *p_usb_iserial) {
 
     if (reset) {
         stlink_reset(sl);
+        usleep(10000);
     }
     stlink_version(sl);
     error = stlink_load_device_params(sl);


### PR DESCRIPTION
Previously when running the program, reading the chip version
would fail. Running the program a second time worked. This
sequence is repeated the next time st-flash/st-util is run.

Giving reset 10ms to complete before trying to read the chip
version resolves the issue.

Signed-off-by: Greg Meiste <w30289@motorola.com>