### PR TITLE
Stm32 l4 flash fix

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -432,6 +432,7 @@ static inline void write_flash_cr_snb(stlink_t *sl, uint32_t n) {
 }
 
 static inline void write_flash_cr_bker_pnb(stlink_t *sl, uint32_t n) {
+    stlink_write_debug32(sl, STM32L4_FLASH_SR, 0xFFFFFFFF & ~(1<<STM32L4_FLASH_SR_BSY));
     uint32_t x = read_flash_cr(sl);
     x &=~ STM32L4_FLASH_CR_OPBITS;
     x &=~ STM32L4_FLASH_CR_PAGEMASK;

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -435,6 +435,8 @@ static inline void write_flash_cr_bker_pnb(stlink_t *sl, uint32_t n) {
     uint32_t x = read_flash_cr(sl);
     x &=~ STM32L4_FLASH_CR_OPBITS;
     x &=~ STM32L4_FLASH_CR_PAGEMASK;
+    x &= ~(1<<STM32L4_FLASH_CR_MER1);
+    x &= ~(1<<STM32L4_FLASH_CR_MER2);
     x |= (n << STM32L4_FLASH_CR_PNB);
     x |= (1lu << STM32L4_FLASH_CR_PER);
 #if DEBUG_FLASH


### PR DESCRIPTION
After some time playing with the L4 chip, I realized that quite often the flash erase operation would just fail. Only thing that would make st-util work again was to perform mass erase using st provided st-link utility. Clearing SR before setting the PNB bits and also making sure the mass erase bits are off seem to have fixed it.