### PR TITLE
clamp gdb memory reads to 0x1800

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -1353,6 +1353,12 @@ int serve(stlink_t *sl, st_state_t *st) {
 
                 unsigned adj_start = start % 4;
                 unsigned count_rnd = (count + adj_start + 4 - 1) / 4 * 4;
+                if (count_rnd > sl->flash_pgsz)
+                    count_rnd = sl->flash_pgsz;
+                if (count_rnd > 0x1800)
+                    count_rnd = 0x1800;
+                if (count_rnd < count)
+                    count = count_rnd;
 
                 stlink_read_mem32(sl, start - adj_start, count_rnd);
 


### PR DESCRIPTION
Similar to #371.

I'm trying to backup the flash memory on an EMW3165 with an eBay ST-Link v2 using the following command:
```
$ gdb
GNU gdb (GDB) 7.10
Copyright (C) 2015 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-apple-darwin15.0.0".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word".
(gdb) target extended-remote :4242
Remote debugging using :4242
0x00000000 in ?? ()
(gdb) dump binary memory out.bin 0x8000000 0x8080000
```

`st-util -v99` shows the USB transfer erring out with a -6.  The gdbserver output shows that 0x1ffff chunks of bytes are being requested but this exceeds the magic 0x1800 in the code.

This patch will return at most 0x1800 bytes.  In my testing, it looks like gdb generates the same output file as `st-flash` does after #371.