### PR TITLE
use libusb synchronous api

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -1031,7 +1031,6 @@ int stlink_fread(stlink_t* sl, const char* path, stm32_addr_t addr, size_t size)
 
     int error = -1;
     size_t off;
-    int num_empty = 0;
 
     const int fd = open(path, O_RDWR | O_TRUNC | O_CREAT, 00700);
     if (fd == -1) {

--- a/src/stlink-usb.h
+++ b/src/stlink-usb.h
@@ -21,8 +21,6 @@ extern "C" {
     struct stlink_libusb {
         libusb_context* libusb_ctx;
         libusb_device_handle* usb_handle;
-        struct libusb_transfer* req_trans;
-        struct libusb_transfer* rep_trans;
         unsigned int ep_req;
         unsigned int ep_rep;
         int protocoll;


### PR DESCRIPTION
The st-link backend API is synchronous so just use the libusb synchronous API as well.  This lets us delete a bunch of code.