### PR TITLE
make st-flash clean up on sigint/term/segv, make gdb-server clean up on sigsegv.

### DIFF
--- a/gdbserver/gdb-server.c
+++ b/gdbserver/gdb-server.c
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <signal.h>
 #include <unistd.h>
 #include <sys/types.h>
 #ifdef __MINGW32__
@@ -186,6 +185,7 @@ int main(int argc, char** argv) {
     connected_stlink = sl;
     signal(SIGINT, &cleanup);
     signal(SIGTERM, &cleanup);
+    signal(SIGSEGV, &cleanup);
 
     if (state.reset) {
         stlink_reset(sl);


### PR DESCRIPTION
.. because hitting CTRL-C and re-jigging the USB dongle is super annoying.