### PR TITLE
Trace the read data in stlink_read_debug32 and not the address of the…

### DIFF
--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -732,7 +732,7 @@ int stlink_read_debug32(stlink_t *sl, uint32_t addr, uint32_t *data) {
 
     ret = sl->backend->read_debug32(sl, addr, data);
     if (!ret)
-	    DLOG("*** stlink_read_debug32 %x is %#x\n", data, addr);
+	    DLOG("*** stlink_read_debug32 %x is %#x\n", *data, addr);
 
 	return ret;
 }


### PR DESCRIPTION
The variable is given as pointer to the subroutine. For the trace output we have to use dereference it.