### PR TITLE
st-probe: Initial working stlink_probe_* API and CLI tool

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ marpe@mimuw.edu.pl
 marco.cassinerio@gmail.com
 jserv@0xlab.org
 michael@pratt.im
+jerry.jacobs@xor-gate.org

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,10 @@ target_link_libraries(st-util stlink)
 add_executable(st-info src/st-info.c)
 target_link_libraries(st-info stlink)
 
-install(TARGETS  stlink st-flash st-util st-info
+add_executable(st-probe src/st-probe.c)
+target_link_libraries(st-probe stlink)
+
+install(TARGETS  stlink st-flash st-util st-info st-probe
         RUNTIME DESTINATION bin
         ARCHIVE DESTINATION lib)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,9 +5,9 @@ SUBDIRS = . $(MAYBE_GUI)
 AUTOMAKE_OPTIONS = subdir-objects
 
 if MINGW
-bin_PROGRAMS = st-flash st-util st-info
+bin_PROGRAMS = st-flash st-util st-info st-probe
 else
-bin_PROGRAMS = st-flash st-util st-term st-info
+bin_PROGRAMS = st-flash st-util st-term st-info st-probe
 endif
 
 noinst_LIBRARIES      = libstlink.a
@@ -15,6 +15,7 @@ noinst_LIBRARIES      = libstlink.a
 st_flash_SOURCES = flash/main.c
 st_term_SOURCES = src/st-term.c
 st_info_SOURCES = src/st-info.c
+st_probe_SOURCES = src/st-probe.c
 st_util_SOURCES = gdbserver/gdb-remote.c gdbserver/gdb-remote.h gdbserver/gdb-server.c mingw/mingw.c mingw/mingw.h
 
 CFILES = \
@@ -52,6 +53,7 @@ st_term_CPPFLAGS        = -std=gnu99 -Wall -Wextra -O2 -I$(top_srcdir)/src -I$(t
 st_info_LDADD   =       libstlink.a
 st_info_CPPFLAGS        = -std=gnu99 -Wall -Wextra -O2 -I$(top_srcdir)/src -I$(top_srcdir)/mingw
 
+st_probe_LDADD   =       libstlink.a
+st_probe_CPPFLAGS       = -std=gnu99 -Wall -Wextra -O2 -I$(top_srcdir)/src -I$(top_srcdir)/mingw
 
 EXTRA_DIST = autogen.sh
-

--- a/src/st-probe.c
+++ b/src/st-probe.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include "stlink-common.h"
+
+void stlink_print_info(stlink_t *sl)
+{
+	const chip_params_t *params = NULL;
+
+	for (size_t n = 0; n < sizeof(sl->serial); n++)
+		printf("%02x", sl->serial[n]);
+	printf("\n");
+
+	printf("\t flash: %zu (pagesize: %zu)\n", sl->flash_size, sl->flash_pgsz);
+	printf("\t  sram: %zu\n",       sl->sram_size);
+	printf("\tchipid: 0x%.4x\n",    sl->chip_id);
+
+	for (size_t i = 0; i < sizeof(devices) / sizeof(devices[0]); i++) {
+		if(devices[i].chip_id == sl->chip_id) {
+			params = &devices[i];
+			break;
+		}
+	}
+
+	if (params)
+		printf("\t descr: %s\n", params->description);
+}
+
+int main(void)
+{
+	stlink_t **stdevs;
+	size_t size;
+
+	size = stlink_probe_usb(&stdevs);
+
+	printf("Found %zu stlink programmers\n", size);
+
+	for (size_t n = 0; n < size; n++)
+		stlink_print_info(stdevs[n]);
+
+	stlink_probe_usb_free(&stdevs, size);
+
+	return EXIT_SUCCESS;
+}

--- a/src/stlink-common.h
+++ b/src/stlink-common.h
@@ -641,6 +641,8 @@ extern "C" {
         uint32_t chip_id;
         int core_stat;
 
+        char serial[13];
+
 #define STM32_FLASH_PGSZ 1024
 #define STM32L_FLASH_PGSZ 256
 

--- a/src/stlink-usb.h
+++ b/src/stlink-usb.h
@@ -29,7 +29,8 @@ extern "C" {
     };
 
     stlink_t* stlink_open_usb(const int verbose, int reset, char *p_usb_iserial);
-
+    size_t stlink_probe_usb(stlink_t **stdevs[]);
+    void stlink_probe_usb_free(stlink_t **stdevs[], size_t size);
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
Hi all,

I'm creating a continues integration system where a machine has multiple stlinks connected. There is currently no good auto-probe tool/library to find the current connected usb stlinks. With this autoprobe I generate openocd configurations to attach to all the programmers.

The following changes have been made:

* Added `stlink_probe_usb`
* Added `stlink_probe_usb_free`
* Extended `stlink_t with serial field`
* Added example CLI tool `st-probe`

Let me know what you think, there is a little code duplication with this addition but the current `stlink_open_usb` is way to big for me to refactor. I tried to refactor the `stlink_open_usb` function but failed and broke the whole thing.

Here is some example output:
```
jjacobs@workbench ~/repos/github/stlink/build $ ./st-probe
Found 2 stlink programmers
563f6706677256563113066700
         flash: 262144 (pagesize: 2048)
          sram: 65536
        chipid: 0x0414
         descr: F1 High-density device
493f6d06667048513615106700
         flash: 1048576 (pagesize: 16384)
          sram: 196608
        chipid: 0x0413
         descr: F4 device
```