### PR TITLE
st-probe: Fix segfault when programmer is already busy

### DIFF
--- a/src/st-probe.c
+++ b/src/st-probe.c
@@ -8,6 +8,9 @@ void stlink_print_info(stlink_t *sl)
 {
 	const chip_params_t *params = NULL;
 
+	if (!sl)
+		return;
+
 	for (size_t n = 0; n < sizeof(sl->serial); n++)
 		printf("%02x", sl->serial[n]);
 	printf("\n");

--- a/src/stlink-common.c
+++ b/src/stlink-common.c
@@ -481,6 +481,8 @@ static inline void write_flash_cr_bker_pnb(stlink_t *sl, uint32_t n) {
 
 void stlink_close(stlink_t *sl) {
     DLOG("*** stlink_close ***\n");
+    if (!sl)
+         return;
     sl->backend->close(sl);
     free(sl);
 }

--- a/src/stlink-usb.c
+++ b/src/stlink-usb.c
@@ -15,6 +15,9 @@
 enum SCSI_Generic_Direction {SG_DXFER_TO_DEV=0, SG_DXFER_FROM_DEV=0x80};
 
 void _stlink_usb_close(stlink_t* sl) {
+    if (!sl)
+        return;
+
     struct stlink_libusb * const handle = sl->backend_data;
     // maybe we couldn't even get the usb device?
     if (handle != NULL) {


### PR DESCRIPTION
With addition of st-probe, it was not previously tested when programmers are already busy. The `stlink_open_usb` then passes a null pointer into the list of programmers. Then on-close it segfaults on the NULL pointer. With this PR it is hardended against NULL pointers.