### PR TITLE
Travis add autotools build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -6,7 +6,13 @@ else
 	brew install libusb
 fi
 
-mkdir build
-cd build
-cmake ..
-make
+if [ "$BUILD_SYSTEM" == "cmake" ]; then
+	mkdir build
+	cd build
+	cmake ..
+	make
+else
+	./autogen.sh
+	./configure
+	make
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,19 @@ matrix:
   include:
     - os: osx
       compiler: clang
+      env: "BUILD_SYSTEM=cmake"
+    - os: osx
+      compiler: clang
+      env: "BUILD_SYSTEM=autotools"
     - os: linux
       compiler: gcc
+      env: "BUILD_SYSTEM=cmake"
     - os: linux
       compiler: clang
+      env: "BUILD_SYSTEM=cmake"
+    - os: linux
+      compiler: gcc
+      env: "BUILD_SYSTEM=autotools"
+    - os: linux
+      compiler: clang
+      env: "BUILD_SYSTEM=autotools"

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Open source version of the STMicroelectronics Stlink Tools
 ==========================================================
 
-[![Build Status](https://travis-ci.org/texane/stlink.svg?branch=travis)](https://travis-ci.org/texane/stlink)
+[![Build Status](https://travis-ci.org/texane/stlink.svg?branch=master)](https://travis-ci.org/texane/stlink)
 
 ## HOWTO
 
@@ -19,9 +19,8 @@ Two different transport layers are used:
 
 ## Common requirements
 
-. libusb-1.0  (You probably already have this, but you'll need the
-development version to compile)
-. pkg-config
+* `pkg-config`
+* `libusb-1.0` (plus development headers for building, on debian based distros `libusb-1.0.0-dev` package)
 
 ## For STLINKv1
 
@@ -31,10 +30,10 @@ is tell your operating system to completely ignore it.
 Options (do one of these before you plug it in)
 
 * `modprobe -r usb-storage && modprobe usb-storage quirks=483:3744:i`
-* or *)1. add "options usb-storage quirks=483:3744:i" to /etc/modprobe.conf
-*   *)2. modprobe -r usb-storage && modprobe usb-storage
-* or *)1. cp stlink_v1.modprobe.conf /etc/modprobe.d
-*   *)2. modprobe -r usb-storage && modprobe usb-storage
+* or 1. `echo "options usb-storage quirks=483:3744:i" >> /etc/modprobe.conf`
+*    2. `modprobe -r usb-storage && modprobe usb-storage`
+* or 1. `cp stlink_v1.modprobe.conf /etc/modprobe.d`
+*    2. `modprobe -r usb-storage && modprobe usb-storage`
 
 ## For STLINKv2
 


### PR DESCRIPTION
This catches bugs earlier for both CMake and Autotools build system as seen in #403 by travis.
It is a bit odd to take care for two build systems, but people can use now what they prefer.

![2016-05-02 17_11_01-build 1 - xor-gate_stlink - travis ci](https://cloud.githubusercontent.com/assets/1050166/14958114/45306ddc-1089-11e6-80ca-0cefc180d691.png)