### PR TITLE
Add support for L0x Category 5 devices

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -137,6 +137,7 @@ extern "C" {
 #define STM32_CHIPID_F04            0x445
 
 #define STM32_CHIPID_F303_HIGH      0x446
+#define STM32_CHIPID_L0_CAT5        0x447
 
 #define STM32_CHIPID_F0_CAN         0x448
 
@@ -503,6 +504,18 @@ extern "C" {
             .sram_size = 0x2000,
             .bootrom_base = 0x1ff0000,
             .bootrom_size = 0x1000
+        },
+        {
+            // STM32L0x Category 5
+            // RM0367,RM0377 documents was used to find these parameters
+            .chip_id = STM32_CHIPID_L0_CAT5,
+            .description = "L0x Category 5 device",
+            .flash_type = FLASH_TYPE_L0,
+            .flash_size_reg = 0x1ff8007c,
+            .flash_pagesize = 0x80,
+            .sram_size = 0x5000,
+            .bootrom_base = 0x1ff0000,
+            .bootrom_size = 0x2000
         },
         {
             // STM32F334

--- a/src/common.c
+++ b/src/common.c
@@ -1288,7 +1288,7 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 
         uint32_t val;
         uint32_t flash_regs_base;
-        if (sl->chip_id == STM32_CHIPID_L0) {
+        if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5) {
             flash_regs_base = STM32L0_FLASH_REGS_ADDR;
         } else {
             flash_regs_base = STM32L_FLASH_REGS_ADDR;
@@ -1667,7 +1667,7 @@ int write_loader_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* size) {
     } else if (sl->chip_id == STM32_CHIPID_F0 || sl->chip_id == STM32_CHIPID_F04 || sl->chip_id == STM32_CHIPID_F0_CAN || sl->chip_id == STM32_CHIPID_F0_SMALL || sl->chip_id == STM32_CHIPID_F09X) {
         loader_code = loader_code_stm32f0;
         loader_size = sizeof(loader_code_stm32f0);
-    } else if (sl->chip_id == STM32_CHIPID_L0) {
+    } else if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5) {
         loader_code = loader_code_stm32l0;
         loader_size = sizeof(loader_code_stm32l0);
     } else if (sl->chip_id == STM32_CHIPID_L4) {
@@ -1747,7 +1747,7 @@ int stm32l1_write_half_pages(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uin
     uint32_t flash_regs_base;
     flash_loader_t fl;
 
-    if (sl->chip_id == STM32_CHIPID_L0) {
+    if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5) {
         flash_regs_base = STM32L0_FLASH_REGS_ADDR;
     } else {
         flash_regs_base = STM32L_FLASH_REGS_ADDR;
@@ -1914,7 +1914,7 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         uint32_t flash_regs_base;
         uint32_t pagesize;
 
-        if (sl->chip_id == STM32_CHIPID_L0) {
+        if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5) {
             flash_regs_base = STM32L0_FLASH_REGS_ADDR;
             pagesize = L0_WRITE_BLOCK_SIZE;
         } else {


### PR DESCRIPTION
support for STM32L0 category 5 devices
tested on L073RZ
flash and sram sizes specified are the biggest possible ones