### PR TITLE
Add L0 Category 2 device (chip id: 0x425)

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -138,6 +138,7 @@ extern "C" {
 
 #define STM32_CHIPID_F303_HIGH      0x446
 #define STM32_CHIPID_L0_CAT5        0x447
+#define STM32_CHIPID_L0_CAT2        0x425
 
 #define STM32_CHIPID_F0_CAN         0x448
 
@@ -516,6 +517,18 @@ extern "C" {
             .sram_size = 0x5000,
             .bootrom_base = 0x1ff0000,
             .bootrom_size = 0x2000
+        },
+        {
+            // STM32L0x Category 2
+            // RM0367,RM0377 documents was used to find these parameters
+            .chip_id = STM32_CHIPID_L0_CAT2,
+            .description = "L0x Category 2 device",
+            .flash_type = FLASH_TYPE_L0,
+            .flash_size_reg = 0x1ff8007c,
+            .flash_pagesize = 0x80,
+            .sram_size = 0x2000,
+            .bootrom_base = 0x1ff0000,
+            .bootrom_size = 0x1000
         },
         {
             // STM32F334

--- a/src/common.c
+++ b/src/common.c
@@ -1288,7 +1288,7 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 
         uint32_t val;
         uint32_t flash_regs_base;
-        if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5) {
+        if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5 || sl->chip_id == STM32_CHIPID_L0_CAT2) {
             flash_regs_base = STM32L0_FLASH_REGS_ADDR;
         } else {
             flash_regs_base = STM32L_FLASH_REGS_ADDR;
@@ -1612,7 +1612,7 @@ int write_loader_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* size) {
     if (sl->chip_id == STM32_CHIPID_L1_MEDIUM || sl->chip_id == STM32_CHIPID_L1_CAT2
             || sl->chip_id == STM32_CHIPID_L1_MEDIUM_PLUS || sl->chip_id == STM32_CHIPID_L1_HIGH
             || sl->chip_id == STM32_CHIPID_L152_RE
-            || sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5) { /* stm32l */
+            || sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5 || sl->chip_id == STM32_CHIPID_L0_CAT2) { /* stm32l */
         loader_code = loader_code_stm32l;
         loader_size = sizeof(loader_code_stm32l);
     } else if (sl->core_id == STM32VL_CORE_ID 
@@ -1720,7 +1720,7 @@ int stm32l1_write_half_pages(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uin
     uint32_t flash_regs_base;
     flash_loader_t fl;
 
-    if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5) {
+    if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5 || sl->chip_id == STM32_CHIPID_L0_CAT2) {
         flash_regs_base = STM32L0_FLASH_REGS_ADDR;
     } else {
         flash_regs_base = STM32L_FLASH_REGS_ADDR;
@@ -1887,7 +1887,7 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         uint32_t flash_regs_base;
         uint32_t pagesize;
 
-        if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5) {
+        if (sl->chip_id == STM32_CHIPID_L0 || sl->chip_id == STM32_CHIPID_L0_CAT5 || sl->chip_id == STM32_CHIPID_L0_CAT2) {
             flash_regs_base = STM32L0_FLASH_REGS_ADDR;
             pagesize = L0_WRITE_BLOCK_SIZE;
         } else {


### PR DESCRIPTION
I tried it with: [NUCLEO-L031K6](http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1847/PF262547)
I'm not sure about the sram_size, but based on [this](http://www.st.com/web/catalog/mmc/FM141/SC1544/SS1833/LN1862) and [RM0377](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/reference_manual/DM00108282.pdf) every category 2 device has 8 kB SRAM (now).