### PR TITLE
Fix const warning on struct stlink_chipid_params

### DIFF
--- a/src/chipid.c
+++ b/src/chipid.c
@@ -389,7 +389,7 @@ static const struct stlink_chipid_params devices[] = {
 
 const struct stlink_chipid_params *stlink_chipid_get_params(uint32_t chipid)
 {
-	struct stlink_chipid_params *params = NULL;
+	const struct stlink_chipid_params *params = NULL;
 
 	for (size_t n = 0; n < STLINK_ARRAY_SIZE(devices); n++) {
 		if (devices[n].chip_id == chipid) {

--- a/src/common.c
+++ b/src/common.c
@@ -567,7 +567,7 @@ int stlink_cpu_id(stlink_t *sl, cortex_m3_cpuid_t *cpuid) {
  */
 int stlink_load_device_params(stlink_t *sl) {
     ILOG("Loading device parameters....\n");
-    struct stlink_chipid_params *params = NULL;
+    const struct stlink_chipid_params *params = NULL;
     stlink_core_id(sl);
     uint32_t chip_id;
     uint32_t flash_size;


### PR DESCRIPTION
Just fix the 2 warnings:

    warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]