### PR TITLE
travis: Add gcc-5 and clang-3.8 to matrix for linux cmake builds

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+echo "-- C compilers available"
+ls -1 /usr/bin/gcc*
+ls -1 /usr/bin/clang*
+ls -1 /usr/bin/scan-build*
+echo "----"
+
 if [ "$TRAVIS_OS_NAME" != "osx" ]; then
 	sudo apt-get update -qq || true
 	sudo apt-get install -qq -y --no-install-recommends libusb-1.0.0-dev libgtk-3-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,33 @@
 sudo: true
 language: c
+addons:
+  apt:
+    sources:
+      - llvm-toolchain-precise-3.8
+      - ubuntu-toolchain-r-test
+    packages:
+      - clang-3.8
+      - g++-5
+      - gcc-5
 script:
   - ./.travis.sh
 matrix:
   include:
-    - os: osx
-      compiler: clang
-      env: "BUILD_SYSTEM=cmake"
-    - os: osx
-      compiler: clang
-      env: "BUILD_SYSTEM=autotools"
-    - os: linux
-      compiler: gcc
-      env: "BUILD_SYSTEM=cmake"
-    - os: linux
-      compiler: clang
-      env: "BUILD_SYSTEM=cmake"
     - os: linux
       compiler: gcc
       env: "BUILD_SYSTEM=autotools"
     - os: linux
+      compiler: clang
+      env: "BUILD_SYSTEM=autotools"
+    - os: linux
+      compiler: gcc-5
+      env: "BUILD_SYSTEM=cmake"
+    - os: linux
+      compiler: clang-3.8
+      env: "BUILD_SYSTEM=cmake"
+    - os: osx
+      compiler: clang
+      env: "BUILD_SYSTEM=cmake"
+    - os: osx
       compiler: clang
       env: "BUILD_SYSTEM=autotools"


### PR DESCRIPTION
Enable gcc 5 and clang 3.8 compilers for Travis continuous integration