### PR TITLE
Do a JTAG reset prior to reading CPU information

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -877,6 +877,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[16
     }
 
     if (reset) {
+        stlink_jtag_reset(sl, 2);
         stlink_reset(sl);
         usleep(10000);
     }


### PR DESCRIPTION
When a microcontroller is in deep sleep (stop) mode, its debug interface is turned off. Programming would therefore fail because st-flash was unable to identify the CPU. This change adds a JTAG reset prior to requesting CPU information. This change has been successfully tested with a Nucleo STM32L031 board.