### PR TITLE
Fix an erase error in stm32f030 device.

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -298,20 +298,29 @@ static void __attribute__((unused)) clear_flash_cr_per(stlink_t *sl) {
 }
 
 static void set_flash_cr_mer(stlink_t *sl) {
-    uint32_t val, cr_reg, cr_mer;
+    uint32_t val, cr_reg, cr_mer, cr_pg;
 
     if (sl->flash_type == STLINK_FLASH_TYPE_F4) {
         cr_reg = FLASH_F4_CR;
         cr_mer = 1 << FLASH_CR_MER;
+        cr_pg = 1 << FLASH_CR_PG;
     } else if (sl->flash_type == STLINK_FLASH_TYPE_L4) {
         cr_reg = STM32L4_FLASH_CR;
         cr_mer = (1 << STM32L4_FLASH_CR_MER1) | (1 << STM32L4_FLASH_CR_MER2);
+        cr_pg = 1 << STM32L4_FLASH_CR_PG;
     } else {
         cr_reg = FLASH_CR;
         cr_mer = 1 << FLASH_CR_MER;
+        cr_pg = 1 << FLASH_CR_PG;
     }
 
     stlink_read_debug32(sl, cr_reg, &val);
+    if (val & cr_pg) {
+        /* STM32F030 will drop MER bit if PG was set */
+        val &= ~cr_pg;
+        stlink_write_debug32(sl, cr_reg, val);
+    }
+
     val |= cr_mer;
     stlink_write_debug32(sl, cr_reg, val);
 }


### PR DESCRIPTION
I run into flashing error with stm32f030. With some
debugging I find out that the mass erase bit was dropped
when flash programming bit already set on FLASH_CR.
This cause erase and write error with my stm32f030
board.

Mass erase never need the programming bit. Turn off the
programming bit make stlink flash stm32f030 successfully.