### PR TITLE
Fix gdb and flash support for the STM32F769I-Disco board.

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1163,7 +1163,7 @@ uint32_t calculate_F4_sectornum(uint32_t flashaddr){
     if (flashaddr >= 0x100000) {
         offset = 12;
         flashaddr -= 0x100000;
-    } 
+    }
     if (flashaddr<0x4000) return (offset + 0);
     else if(flashaddr<0x8000) return(offset + 1);
     else if(flashaddr<0xc000) return(offset + 2);
@@ -1211,7 +1211,7 @@ uint32_t stlink_calculate_pagesize(stlink_t *sl, uint32_t flashaddr){
         else if(sector<5) sl->flash_pgsz=0x10000;
         else sl->flash_pgsz=0x20000;
     }
-    else if (sl->chip_id == STLINK_CHIPID_STM32_F7) {
+    else if (sl->chip_id == STLINK_CHIPID_STM32_F7 || sl->chip_id == STLINK_CHIPID_STM32_F7XXXX) {
         uint32_t sector=calculate_F7_sectornum(flashaddr);
         if (sector<4) sl->flash_pgsz=0x8000;
         else if(sector<5) sl->flash_pgsz=0x20000;
@@ -1243,7 +1243,7 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
             fprintf(stderr, "EraseFlash - Page:0x%x Size:0x%x ", page, stlink_calculate_pagesize(sl, flashaddr));
 
             write_flash_cr_bker_pnb(sl, page);
-        } else if (sl->chip_id == STLINK_CHIPID_STM32_F7) {
+        } else if (sl->chip_id == STLINK_CHIPID_STM32_F7 || sl->chip_id == STLINK_CHIPID_STM32_F7XXXX) {
             // calculate the actual page from the address
             uint32_t sector=calculate_F7_sectornum(flashaddr);
 
@@ -1255,7 +1255,7 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
             uint32_t sector=calculate_F4_sectornum(flashaddr);
 
             fprintf(stderr, "EraseFlash - Sector:0x%x Size:0x%x ", sector, stlink_calculate_pagesize(sl, flashaddr));
-        
+
             //the SNB values for flash sectors in the second bank do not directly follow the values for the first bank on 2mb devices...
             if (sector >= 12) sector += 4;
 

--- a/src/gdbserver/gdb-server.c
+++ b/src/gdbserver/gdb-server.c
@@ -429,7 +429,7 @@ char* make_memory_map(stlink_t *sl) {
 
     if(sl->chip_id==STLINK_CHIPID_STM32_F4 || sl->chip_id==STLINK_CHIPID_STM32_F446) {
         strcpy(map, memory_map_template_F4);
-    } else if(sl->chip_id==STLINK_CHIPID_STM32_F4 || sl->chip_id==STLINK_CHIPID_STM32_F7) {
+    } else if(sl->chip_id==STLINK_CHIPID_STM32_F4 || sl->core_id==STM32F7_CORE_ID) {
         strcpy(map, memory_map_template_F7);
     } else if(sl->chip_id==STLINK_CHIPID_STM32_F4_HD) {
         strcpy(map, memory_map_template_F4_HD);
@@ -601,7 +601,7 @@ static int update_code_breakpoint(stlink_t *sl, stm32_addr_t addr, int set) {
         return -1;
     }
 
-	if (sl->chip_id==STLINK_CHIPID_STM32_F7) {
+	if (sl->core_id==STM32F7_CORE_ID) {
 		fpb_addr = addr;
 	} else {
 		fpb_addr = addr & ~0x3;
@@ -625,7 +625,7 @@ static int update_code_breakpoint(stlink_t *sl, stm32_addr_t addr, int set) {
 
     brk->addr = fpb_addr;
 
-	if (sl->chip_id==STLINK_CHIPID_STM32_F7) {
+	if (sl->core_id==STM32F7_CORE_ID) {
 		if(set) brk->type = type;
 		else	brk->type = 0;
 
@@ -751,7 +751,7 @@ static int flash_go(stlink_t *sl) {
                         send, 0) < 0)
                 goto error;
             length -= send;
-            
+
         }
     }
 
@@ -835,7 +835,7 @@ static void init_cache (stlink_t *sl) {
   int i;
 
   /* Assume only F7 has a cache.  */
-  if(sl->chip_id!=STLINK_CHIPID_STM32_F7)
+  if(sl->core_id!=STM32F7_CORE_ID)
     return;
 
   stlink_read_debug32(sl, CLIDR, &clidr);
@@ -916,7 +916,7 @@ static void cache_sync(stlink_t *sl)
 {
   unsigned ccr;
 
-  if(sl->chip_id!=STLINK_CHIPID_STM32_F7)
+  if(sl->core_id!=STM32F7_CORE_ID)
     return;
   if (!cache_modified)
     return;
@@ -1019,7 +1019,7 @@ int serve(stlink_t *sl, st_state_t *st) {
                 if(!strcmp(queryName, "Supported")) {
                     if(sl->chip_id==STLINK_CHIPID_STM32_F4
 		       || sl->chip_id==STLINK_CHIPID_STM32_F4_HD
-		       || sl->chip_id==STLINK_CHIPID_STM32_F7) {
+                       || sl->core_id==STM32F7_CORE_ID) {
                         reply = strdup("PacketSize=3fff;qXfer:memory-map:read+;qXfer:features:read+");
                     }
                     else {


### PR DESCRIPTION
The STM32F76XXX having a different Chip ID than the STM32F74x, we need to check for the Core ID for STM32F7-specific handling.