### PR TITLE
Fix memory map for STM32F7xxx

### DIFF
--- a/src/chipid.c
+++ b/src/chipid.c
@@ -9,7 +9,7 @@ static const struct stlink_chipid_params devices[] = {
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1ff0f442,      // section 45.2
             .flash_pagesize = 0x800,           // No flash pages
-            .sram_size = 0x5C000,              // "SRAM" byte size in hex from 
+            .sram_size = 0x80000,              // "SRAM" byte size in hex from
             .bootrom_base = 0x00200000,        //! "System memory" starting address from 
             .bootrom_size = 0xEDC0             //! @todo "System memory" byte size in hex from 
         },


### PR DESCRIPTION
Also:
- fixed a typo in an if statement condition in make_memory_map
- cleaned up usage of '4096' in favor of const size_t sz = 4096.