### PR TITLE
Support of Intel-HEX format for st-flash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,11 @@ if (APPLE)
 	target_link_libraries(${PROJECT_NAME} ${CoreFoundation} ${IOKit} ${ObjC})
 endif ()
 
+add_library(stflash STATIC
+            src/tools/flash_opts.c)
+target_link_libraries(${PROJECT_NAME} ${LIBUSB_LIBRARY})
 add_executable(st-flash src/tools/flash.c)
-target_link_libraries(st-flash ${PROJECT_NAME})
+target_link_libraries(st-flash ${PROJECT_NAME} stflash)
 
 add_executable(st-info src/tools/info.c)
 target_link_libraries(st-info ${PROJECT_NAME})

--- a/include/stlink.h
+++ b/include/stlink.h
@@ -180,9 +180,10 @@ typedef struct flash_loader {
 
     int stlink_erase_flash_mass(stlink_t* sl);
     int stlink_write_flash(stlink_t* sl, stm32_addr_t address, uint8_t* data, uint32_t length, uint8_t eraseonly);
-		uint8_t stlink_parse_hex(const char* hex);
-		int stlink_parse_ihex(const char* path, uint8_t erased_pattern, uint8_t * * mem, size_t * size, uint32_t * begin);
-    int stlink_fwrite_flash(stlink_t *sl, const char* path, bool is_ihex, stm32_addr_t addr);
+    int stlink_parse_ihex(const char* path, uint8_t erased_pattern, uint8_t * * mem, size_t * size, uint32_t * begin);
+    uint8_t stlink_get_erased_pattern(stlink_t *sl);
+    int stlink_mwrite_flash(stlink_t *sl, uint8_t* data, uint32_t length, stm32_addr_t addr);
+    int stlink_fwrite_flash(stlink_t *sl, const char* path, stm32_addr_t addr);
     int stlink_fwrite_sram(stlink_t *sl, const char* path, stm32_addr_t addr);
     int stlink_verify_write_flash(stlink_t *sl, stm32_addr_t address, uint8_t *data, uint32_t length);
 
@@ -201,7 +202,7 @@ typedef struct flash_loader {
     bool stlink_is_core_halted(stlink_t *sl);
     int write_buffer_to_sram(stlink_t *sl, flash_loader_t* fl, const uint8_t* buf, size_t size);
     int write_loader_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* size);
-    int stlink_fread(stlink_t* sl, const char* path, stm32_addr_t addr, size_t size);
+    int stlink_fread(stlink_t* sl, const char* path, bool is_ihex, stm32_addr_t addr, size_t size);
     int stlink_load_device_params(stlink_t *sl);
 
 #include "stlink/sg.h"

--- a/include/stlink.h
+++ b/include/stlink.h
@@ -184,6 +184,7 @@ typedef struct flash_loader {
     uint8_t stlink_get_erased_pattern(stlink_t *sl);
     int stlink_mwrite_flash(stlink_t *sl, uint8_t* data, uint32_t length, stm32_addr_t addr);
     int stlink_fwrite_flash(stlink_t *sl, const char* path, stm32_addr_t addr);
+    int stlink_mwrite_sram(stlink_t *sl, uint8_t* data, uint32_t length, stm32_addr_t addr);
     int stlink_fwrite_sram(stlink_t *sl, const char* path, stm32_addr_t addr);
     int stlink_verify_write_flash(stlink_t *sl, stm32_addr_t address, uint8_t *data, uint32_t length);
 

--- a/include/stlink.h
+++ b/include/stlink.h
@@ -180,7 +180,9 @@ typedef struct flash_loader {
 
     int stlink_erase_flash_mass(stlink_t* sl);
     int stlink_write_flash(stlink_t* sl, stm32_addr_t address, uint8_t* data, uint32_t length, uint8_t eraseonly);
-    int stlink_fwrite_flash(stlink_t *sl, const char* path, stm32_addr_t addr);
+		uint8_t stlink_parse_hex(const char* hex);
+		int stlink_parse_ihex(const char* path, uint8_t erased_pattern, uint8_t * * mem, size_t * size, uint32_t * begin);
+    int stlink_fwrite_flash(stlink_t *sl, const char* path, bool is_ihex, stm32_addr_t addr);
     int stlink_fwrite_sram(stlink_t *sl, const char* path, stm32_addr_t addr);
     int stlink_verify_write_flash(stlink_t *sl, stm32_addr_t address, uint8_t *data, uint32_t length);
 

--- a/include/stlink/tools/flash.h
+++ b/include/stlink/tools/flash.h
@@ -1,0 +1,28 @@
+#ifndef STLINK_TOOLS_FLASH_H_
+#define STLINK_TOOLS_FLASH_H_
+
+#include <stdint.h>
+#include <stlink.h>
+
+#define DEBUG_LOG_LEVEL 100
+#define STND_LOG_LEVEL  50
+
+enum flash_cmd {FLASH_CMD_NONE = 0, FLASH_CMD_WRITE = 1, FLASH_CMD_READ = 2, FLASH_CMD_ERASE = 3};
+enum flash_format {FLASH_FORMAT_BINARY = 0, FLASH_FORMAT_IHEX = 1};
+struct flash_opts
+{
+    enum flash_cmd cmd;
+    const char* devname;
+    uint8_t serial[16];
+    const char* filename;
+    stm32_addr_t addr;
+    size_t size;
+    int reset;
+    int log_level;
+    enum flash_format format;
+};
+
+int flash_get_opts(struct flash_opts* o, int ac, char** av);
+
+#endif // STLINK_FLASH_H_
+

--- a/src/common.c
+++ b/src/common.c
@@ -1096,17 +1096,11 @@ on_error:
     return error;
 }
 
-int stlink_fread(stlink_t* sl, const char* path, stm32_addr_t addr, size_t size) {
-    /* read size bytes from addr to file */
+typedef bool (*save_block_fn)(void* arg, uint8_t* block, ssize_t len);
+
+static int stlink_read(stlink_t* sl, stm32_addr_t addr, size_t size, save_block_fn fn, void* fn_arg) {
 
     int error = -1;
-    size_t off;
-
-    const int fd = open(path, O_RDWR | O_TRUNC | O_CREAT, 00700);
-    if (fd == -1) {
-        fprintf(stderr, "open(%s) == -1\n", path);
-        return -1;
-    }
 
     if (size <1)
         size = sl->flash_size;
@@ -1115,7 +1109,7 @@ int stlink_fread(stlink_t* sl, const char* path, stm32_addr_t addr, size_t size)
         size = sl->flash_size;
 
     size_t cmp_size = (sl->flash_pgsz > 0x1800)? 0x1800:sl->flash_pgsz;
-    for (off = 0; off < size; off += cmp_size) {
+    for (size_t off = 0; off < size; off += cmp_size) {
         size_t aligned_size;
 
         /* adjust last page size */
@@ -1128,8 +1122,7 @@ int stlink_fread(stlink_t* sl, const char* path, stm32_addr_t addr, size_t size)
 
         stlink_read_mem32(sl, addr + (uint32_t) off, aligned_size);
 
-        if (write(fd, sl->q_buf, sl->q_len) != (ssize_t) aligned_size) {
-            fprintf(stderr, "write() != aligned_size\n");
+        if (!fn(fn_arg, sl->q_buf, aligned_size)) {
             goto on_error;
         }
     }
@@ -1138,6 +1131,134 @@ int stlink_fread(stlink_t* sl, const char* path, stm32_addr_t addr, size_t size)
     error = 0;
 
 on_error:
+    return error;
+}
+
+struct stlink_fread_worker_arg {
+    int fd;
+};
+
+static bool stlink_fread_worker(void* arg, uint8_t* block, ssize_t len) {
+    struct stlink_fread_worker_arg* the_arg = (struct stlink_fread_worker_arg*)arg;
+    if (write(the_arg->fd, block, len) != len) {
+        fprintf(stderr, "write() != aligned_size\n");
+        return false;
+    }
+    else {
+        return true;
+    }
+}
+
+struct stlink_fread_ihex_worker_arg {
+    FILE* file;
+    uint32_t addr;
+    uint32_t lba;
+    uint8_t buf[16];
+    uint8_t buf_pos;
+};
+
+static bool stlink_fread_ihex_newsegment(struct stlink_fread_ihex_worker_arg* the_arg) {
+    uint32_t addr = the_arg->addr;
+    uint8_t sum = 2 + 4 + (uint8_t)((addr & 0xFF000000) >> 24) + (uint8_t)((addr & 0x00FF0000) >> 16);
+    if(17 != fprintf(the_arg->file, ":02000004%04X%02X\r\n", (addr & 0xFFFF0000) >> 16, (uint8_t)(0x100 - sum)))
+        return false;
+
+    the_arg->lba = (addr & 0xFFFF0000);
+
+    return true;
+}
+
+static bool stlink_fread_ihex_writeline(struct stlink_fread_ihex_worker_arg* the_arg) {
+    uint8_t count = the_arg->buf_pos;
+    if(count == 0) return true;
+
+    uint32_t addr = the_arg->addr;
+
+    if(the_arg->lba != (addr & 0xFFFF0000)) { // segment changed
+        if(!stlink_fread_ihex_newsegment(the_arg)) return false;
+    }
+
+    uint8_t sum = count + (uint8_t)((addr & 0x0000FF00) >> 8) + (uint8_t)(addr & 0x000000FF);
+    if(9 != fprintf(the_arg->file, ":%02X%04X00", count, (addr & 0x0000FFFF)))
+        return false;
+
+    for(uint8_t i = 0; i < count; ++i) {
+        uint8_t b = the_arg->buf[i];
+        sum += b;
+        if(2 != fprintf(the_arg->file, "%02X", b))
+            return false;
+    }
+
+    if(4 != fprintf(the_arg->file, "%02X\r\n", (uint8_t)(0x100 - sum)))
+        return false;
+
+    the_arg->addr += count;
+    the_arg->buf_pos = 0;
+
+    return true;
+}
+
+static bool stlink_fread_ihex_init(struct stlink_fread_ihex_worker_arg* the_arg, int fd, stm32_addr_t addr) {
+    the_arg->file    = fdopen(fd, "w");
+    the_arg->addr    = addr;
+    the_arg->lba     = 0;
+    the_arg->buf_pos = 0;
+
+    return (the_arg->file != NULL);
+}
+
+static bool stlink_fread_ihex_worker(void* arg, uint8_t* block, ssize_t len) {
+    struct stlink_fread_ihex_worker_arg* the_arg = (struct stlink_fread_ihex_worker_arg*)arg;
+
+    for(ssize_t i = 0; i < len; ++i) {
+        if(the_arg->buf_pos == sizeof(the_arg->buf)) { // line is full
+            if(!stlink_fread_ihex_writeline(the_arg)) return false;
+        }
+
+        the_arg->buf[the_arg->buf_pos++] = block[i];
+    }
+
+    return true;
+}
+
+static bool stlink_fread_ihex_finalize(struct stlink_fread_ihex_worker_arg* the_arg) {
+    if(!stlink_fread_ihex_writeline(the_arg)) return false;
+
+    // FIXME do we need the Start Linear Address?
+
+    if(13 != fprintf(the_arg->file, ":00000001FF\r\n")) // EoF
+        return false;
+
+    return (0 == fclose(the_arg->file));
+}
+
+int stlink_fread(stlink_t* sl, const char* path, bool is_ihex, stm32_addr_t addr, size_t size) {
+    /* read size bytes from addr to file */
+
+    int error;
+
+    int fd = open(path, O_RDWR | O_TRUNC | O_CREAT, 00700);
+    if (fd == -1) {
+        fprintf(stderr, "open(%s) == -1\n", path);
+        return -1;
+    }
+
+    if(is_ihex) {
+        struct stlink_fread_ihex_worker_arg arg;
+        if(stlink_fread_ihex_init(&arg, fd, addr)) {
+            error = stlink_read(sl, addr, size, &stlink_fread_ihex_worker, &arg);
+            if(!stlink_fread_ihex_finalize(&arg))
+                error = -1;
+        }
+        else {
+            error = -1;
+        }
+    }
+    else {
+        struct stlink_fread_worker_arg arg = { fd };
+        error = stlink_read(sl, addr, size, &stlink_fread_worker, &arg);
+    }
+
     close(fd);
 
     return error;
@@ -1755,170 +1876,199 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
 }
 
 // note: length not checked
-uint8_t stlink_parse_hex(const char* hex) {
-	uint8_t d[2];
-	for(int i = 0; i < 2; ++i) {
-		char c = *(hex + i);
-		if(c >= '0' && c <= '9') d[i] = c - '0';
-		else if(c >= 'A' && c <= 'F') d[i] = c - 'A' + 10;
-		else if(c >= 'a' && c <= 'f') d[i] = c - 'a' + 10;
-		else return 0; // error
-	}
-	return (d[0] << 4) | (d[1]);
+static uint8_t stlink_parse_hex(const char* hex) {
+    uint8_t d[2];
+    for(int i = 0; i < 2; ++i) {
+        char c = *(hex + i);
+        if(c >= '0' && c <= '9') d[i] = c - '0';
+        else if(c >= 'A' && c <= 'F') d[i] = c - 'A' + 10;
+        else if(c >= 'a' && c <= 'f') d[i] = c - 'a' + 10;
+        else return 0; // error
+    }
+    return (d[0] << 4) | (d[1]);
 }
 
 int stlink_parse_ihex(const char* path, uint8_t erased_pattern, uint8_t * * mem, size_t * size, uint32_t * begin) {
-	int res = 0;
-	*begin = UINT32_MAX;
-	uint8_t* data = NULL;
-	uint32_t end = 0;
-	bool eof_found = false;
+    int res = 0;
+    *begin = UINT32_MAX;
+    uint8_t* data = NULL;
+    uint32_t end = 0;
+    bool eof_found = false;
 
-	for(int scan = 0; (res == 0) && (scan < 2); ++scan) { // parse file two times - first to find memory range, second - to fill it
-		if(scan == 1) {
-			if(!eof_found) {
-				ELOG("No EoF recond\n");
-				res = -1;
-				break;
-			}
+    for(int scan = 0; (res == 0) && (scan < 2); ++scan) { // parse file two times - first to find memory range, second - to fill it
+        if(scan == 1) {
+            if(!eof_found) {
+                ELOG("No EoF recond\n");
+                res = -1;
+                break;
+            }
 
-			if(*begin >= end) {
-				ELOG("No data found in file\n");
-				res = -1;
-				break;
-			}
+            if(*begin >= end) {
+                ELOG("No data found in file\n");
+                res = -1;
+                break;
+            }
 
-			*size = (end - *begin) + 1;
-			data = calloc(*size, 1); // use calloc to get NULL if out of memory
-			if(!data) {
-				ELOG("Cannot allocate %d bytes\n", *size);
-				res = -1;
-				break;
-			}
+            *size = (end - *begin) + 1;
+            data = calloc(*size, 1); // use calloc to get NULL if out of memory
+            if(!data) {
+                ELOG("Cannot allocate %d bytes\n", *size);
+                res = -1;
+                break;
+            }
 
-			memset(data, erased_pattern, *size);
-		}
+            memset(data, erased_pattern, *size);
+        }
 
-		FILE* file = fopen(path, "r");
-		if(!file) {
-			ELOG("Cannot open file\n");
-			res = -1;
-			break;
-		}
+        FILE* file = fopen(path, "r");
+        if(!file) {
+            ELOG("Cannot open file\n");
+            res = -1;
+            break;
+        }
 
-		uint32_t lba = 0;
+        uint32_t lba = 0;
 
-		char line[1 + 5*2 + 255*2 + 2];
-		while(fgets(line, sizeof(line), file)) {
-			if(line[0] == '\n' || line[0] == '\r') continue; // skip empty lines
-			if(line[0] != ':') { // no marker - wrong file format
-				ELOG("Wrong file format - no marker\n");
-				res = -1;
-				break;
-			}
+        char line[1 + 5*2 + 255*2 + 2];
+        while(fgets(line, sizeof(line), file)) {
+            if(line[0] == '\n' || line[0] == '\r') continue; // skip empty lines
+            if(line[0] != ':') { // no marker - wrong file format
+                ELOG("Wrong file format - no marker\n");
+                res = -1;
+                break;
+            }
 
-			size_t l = strlen(line);
-			while(l > 0 && (line[l-1] == '\n' || line[l-1] == '\r')) --l; // trim EoL
-			if((l < 11) || (l == (sizeof(line)-1))) { // line too short or long - wrong file format
-				ELOG("Wrong file format - wrong line length\n");
-				res = -1;
-				break;
-			}
+            size_t l = strlen(line);
+            while(l > 0 && (line[l-1] == '\n' || line[l-1] == '\r')) --l; // trim EoL
+            if((l < 11) || (l == (sizeof(line)-1))) { // line too short or long - wrong file format
+                ELOG("Wrong file format - wrong line length\n");
+                res = -1;
+                break;
+            }
 
-			// check sum
-			uint8_t chksum = 0;
-			for(size_t i = 1; i < l; i += 2) {
-				chksum += stlink_parse_hex(line + i);
-			}
-			if(chksum != 0) {
-				ELOG("Wrong file format - checksum mismatch\n");
-				res = -1;
-				break;
-			}
+            // check sum
+            uint8_t chksum = 0;
+            for(size_t i = 1; i < l; i += 2) {
+                chksum += stlink_parse_hex(line + i);
+            }
+            if(chksum != 0) {
+                ELOG("Wrong file format - checksum mismatch\n");
+                res = -1;
+                break;
+            }
 
-			uint8_t reclen = stlink_parse_hex(line + 1);
-			if(((uint32_t)reclen + 5)*2 + 1 != l) {
-				ELOG("Wrong file format - record length mismatch\n");
-				res = -1;
-				break;
-			}
+            uint8_t reclen = stlink_parse_hex(line + 1);
+            if(((uint32_t)reclen + 5)*2 + 1 != l) {
+                ELOG("Wrong file format - record length mismatch\n");
+                res = -1;
+                break;
+            }
 
-			uint16_t offset  = ((uint16_t)stlink_parse_hex(line + 3) << 8) | ((uint16_t)stlink_parse_hex(line + 5));
-			uint8_t  rectype = stlink_parse_hex(line + 7);
+            uint16_t offset  = ((uint16_t)stlink_parse_hex(line + 3) << 8) | ((uint16_t)stlink_parse_hex(line + 5));
+            uint8_t  rectype = stlink_parse_hex(line + 7);
 
-			switch(rectype) {
-				case 0: // data
-					if(scan == 0) {
-						uint32_t b = lba + offset;
-						uint32_t e = b + reclen - 1;
-						if(b < *begin) *begin = b;
-						if(e > end) end = e;
-					}
-					else {
-						for(size_t i = 0; i < reclen; ++i) {
-							uint8_t b = stlink_parse_hex(line + 9 + i*2);
-							uint32_t addr = lba + offset + i;
-							if(addr >= *begin && addr <= end) {
-								data[addr - *begin] = b;
-							}
-						}
-					}
-					break;
+            switch(rectype) {
+                case 0: // data
+                    if(scan == 0) {
+                        uint32_t b = lba + offset;
+                        uint32_t e = b + reclen - 1;
+                        if(b < *begin) *begin = b;
+                        if(e > end) end = e;
+                    }
+                    else {
+                        for(size_t i = 0; i < reclen; ++i) {
+                            uint8_t b = stlink_parse_hex(line + 9 + i*2);
+                            uint32_t addr = lba + offset + i;
+                            if(addr >= *begin && addr <= end) {
+                                data[addr - *begin] = b;
+                            }
+                        }
+                    }
+                    break;
 
-				case 1: // EoF
-					eof_found = true;
-					break;
+                case 1: // EoF
+                    eof_found = true;
+                    break;
 
-				case 2: // Extended Segment Address, unexpected
-					res = -1;
-					break;
+                case 2: // Extended Segment Address, unexpected
+                    res = -1;
+                    break;
 
-				case 3: // Start Segment Address, unexpected
-					res = -1;
-					break;
+                case 3: // Start Segment Address, unexpected
+                    res = -1;
+                    break;
 
-				case 4: // Extended Linear Address
-					if(reclen == 2) {
-						lba = ((uint32_t)stlink_parse_hex(line + 9) << 24) | ((uint32_t)stlink_parse_hex(line + 11) << 16);
-					}
-					else {
-						ELOG("Wrong file format - wrong LBA length\n");
-						res = -1;
-					}
-					break;
+                case 4: // Extended Linear Address
+                    if(reclen == 2) {
+                        lba = ((uint32_t)stlink_parse_hex(line + 9) << 24) | ((uint32_t)stlink_parse_hex(line + 11) << 16);
+                    }
+                    else {
+                        ELOG("Wrong file format - wrong LBA length\n");
+                        res = -1;
+                    }
+                    break;
 
-				case 5: // Start Linear Address - expected, but ignore
-					break;
+                case 5: // Start Linear Address - expected, but ignore
+                    break;
 
-				default:
-					ELOG("Wrong file format - unexpected record type %d\n", rectype);
-					res = -1;
-			}
-			if(res != 0) break;
-		}
+                default:
+                    ELOG("Wrong file format - unexpected record type %d\n", rectype);
+                    res = -1;
+            }
+            if(res != 0) break;
+        }
 
-		fclose(file);
-	}
+        fclose(file);
+    }
 
-	if(res == 0) {
-		*mem = data;
-	}
-	else {
-		free(data);
-	}
+    if(res == 0) {
+        *mem = data;
+    }
+    else {
+        free(data);
+    }
 
-	return res;
+    return res;
 }
 
-// FIXME remove
-void dumpMem(uint8_t const * mem, size_t len) {
-	for(size_t i = 0; i < len; ++i) {
-		if(i > 0 && i % 16 == 0) printf("\n");
-		else if(i > 0 && i % 8 == 0) printf(" ");
-		if(i % 16 == 0) printf("%08zx  ", i);
-		printf("%02x ", mem[i]);
-	}
-	printf("\n");
+static void stlink_fwrite_finalize(stlink_t *sl, stm32_addr_t addr) {
+    unsigned int val;
+    /* set stack*/
+    stlink_read_debug32(sl, addr, &val);
+    stlink_write_reg(sl, val, 13);
+    /* Set PC to the reset routine*/
+    stlink_read_debug32(sl, addr + 4, &val);
+    stlink_write_reg(sl, val, 15);
+    stlink_run(sl);
+}
+
+uint8_t stlink_get_erased_pattern(stlink_t *sl) {
+    if (sl->flash_type == STLINK_FLASH_TYPE_L0)
+        return 0x00;
+    else
+        return 0xff;
+}
+
+int stlink_mwrite_flash(stlink_t *sl, uint8_t* data, uint32_t length, stm32_addr_t addr) {
+    /* write the block in flash at addr */
+    int err;
+    unsigned int num_empty, index;
+    uint8_t erased_pattern = stlink_get_erased_pattern(sl);
+
+    index = (unsigned int)length;
+    for(num_empty = 0; num_empty != length; ++num_empty) {
+        if (data[--index] != erased_pattern) {
+            break;
+        }
+    }
+    /* Round down to words */
+    num_empty -= (num_empty & 3);
+    if(num_empty != 0) {
+        ILOG("Ignoring %d bytes of 0x%02x at end of file\n", num_empty, erased_pattern);
+    }
+    err = stlink_write_flash(sl, addr, data, (num_empty == length) ? (uint32_t) length : (uint32_t) length - num_empty, num_empty == length);
+    stlink_fwrite_finalize(sl, addr);
+    return err;
 }
 
 /**
@@ -1928,59 +2078,31 @@ void dumpMem(uint8_t const * mem, size_t len) {
  * @param addr where to start writing
  * @return 0 on success, -ve on failure.
  */
-int stlink_fwrite_flash(stlink_t *sl, const char* path, bool is_ihex, stm32_addr_t addr) {
+int stlink_fwrite_flash(stlink_t *sl, const char* path, stm32_addr_t addr) {
     /* write the file in flash at addr */
     int err;
-    unsigned int num_empty, index, val;
-    unsigned char erased_pattern;
+    unsigned int num_empty, index;
+    uint8_t erased_pattern = stlink_get_erased_pattern(sl);
     mapped_file_t mf = MAPPED_FILE_INITIALIZER;
-		uint8_t * mem;
-		size_t size;
-		bool eraseonly = false;
 
-    if (sl->flash_type == STLINK_FLASH_TYPE_L0)
-        erased_pattern = 0x00;
-    else
-        erased_pattern = 0xff;
+    if (map_file(&mf, path) == -1) {
+        ELOG("map_file() == -1\n");
+        return -1;
+    }
 
-		if(is_ihex) {
-			uint32_t begin;
-			if(0 != stlink_parse_ihex(path, 0xFF, &mem, &size, &begin))
-				return -1;
-			addr = begin;
-		}
-		else {
-			if (map_file(&mf, path) == -1) {
-					ELOG("map_file() == -1\n");
-					return -1;
-			}
-
-			index = (unsigned int) mf.len;
-			for(num_empty = 0; num_empty != mf.len; ++num_empty) {
-					if (mf.base[--index] != erased_pattern) {
-							break;
-					}
-			}
-			/* Round down to words */
-			num_empty -= (num_empty & 3);
-			if(num_empty != 0) {
-					ILOG("Ignoring %d bytes of 0x%02x at end of file\n", num_empty, erased_pattern);
-			}
-			mem = mf.base;
-			size = (num_empty == mf.len) ? (uint32_t) mf.len : (uint32_t) mf.len - num_empty;
-			eraseonly = (num_empty == mf.len);
-		}
-		err = stlink_write_flash(sl, addr, mem, size, eraseonly);
-    /* set stack*/
-    stlink_read_debug32(sl, addr, &val);
-    stlink_write_reg(sl, val, 13);
-    /* Set PC to the reset routine*/
-    stlink_read_debug32(sl, addr + 4, &val);
-    stlink_write_reg(sl, val, 15);
-    stlink_run(sl);
-		if(is_ihex)
-			free(mem);
-		else
-			unmap_file(&mf);
+    index = (unsigned int) mf.len;
+    for(num_empty = 0; num_empty != mf.len; ++num_empty) {
+        if (mf.base[--index] != erased_pattern) {
+            break;
+        }
+    }
+    /* Round down to words */
+    num_empty -= (num_empty & 3);
+    if(num_empty != 0) {
+        ILOG("Ignoring %d bytes of 0x%02x at end of file\n", num_empty, erased_pattern);
+    }
+    err = stlink_write_flash(sl, addr, mf.base, (num_empty == mf.len) ? (uint32_t) mf.len : (uint32_t) mf.len - num_empty, num_empty == mf.len);
+    stlink_fwrite_finalize(sl, addr);
+    unmap_file(&mf);
     return err;
 }

--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -34,6 +34,7 @@ struct opts
     const char* devname;
 	char *serial;
     const char* filename;
+	bool is_ihex;
     stm32_addr_t addr;
     size_t size;
     int reset;
@@ -157,6 +158,7 @@ static int get_opts(struct opts* o, int ac, char** av)
     o->filename = av[i + 1];
     /** @todo This is a little evil as strtoul could return 0 and is of type unsigned long int */
     o->addr = (uint32_t) strtoul(av[i + 2], NULL, 16);
+	o->is_ihex = (0 == strcmp(".hex", o->filename + (strlen(o->filename) - 4))); // ends with .hex
 
     return 0;
 }
@@ -246,7 +248,7 @@ int main(int ac, char** av)
     {
         if ((o.addr >= sl->flash_base) &&
                 (o.addr < sl->flash_base + sl->flash_size)) {
-            err = stlink_fwrite_flash(sl, o.filename, o.addr);
+            err = stlink_fwrite_flash(sl, o.filename, o.is_ihex, o.addr);
             if (err == -1)
             {
                 printf("stlink_fwrite_flash() == -1\n");

--- a/src/tools/flash_opts.c
+++ b/src/tools/flash_opts.c
@@ -1,0 +1,156 @@
+#include <stlink/tools/flash.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+static bool starts_with(const char * str, const char * prefix) {
+    size_t n = strlen(prefix);
+    if(strlen(str) < n) return false;
+
+    return (0 == strncmp(str, prefix, n));
+}
+
+int flash_get_opts(struct flash_opts* o, int ac, char** av)
+{
+    bool serial_specified = false;
+
+    // defaults
+
+    memset(o, 0, sizeof(*o));
+    o->log_level = STND_LOG_LEVEL;
+
+    // options
+
+    while(ac >= 1) {
+        if (strcmp(av[0], "--debug") == 0) {
+            o->log_level = DEBUG_LOG_LEVEL;
+        }
+        else if (strcmp(av[0], "--reset") == 0) {
+            o->reset = 1;
+        }
+        else if (strcmp(av[0], "--serial") == 0 || starts_with(av[0], "--serial=")) {
+            const char * serial;
+            if(strcmp(av[0], "--serial") == 0) {
+                ac--;
+                av++;
+                if (ac < 1) return -1;
+                serial = av[0];
+            }
+            else {
+                serial = av[0] + strlen("--serial=");
+            }
+
+            /** @todo This is not really portable, as strlen really returns size_t we need to obey and not cast it to a signed type. */
+            int j = (int)strlen(serial);
+            if(j % 2 != 0) return -1;
+ 
+            for(size_t k = 0; j >= 0 && k < sizeof(o->serial); ++k, j -= 2) {
+                char buffer[3] = {0};
+                memcpy(buffer, serial + j, 2);
+                o->serial[12 - k] = (uint8_t)strtol(buffer, NULL, 16);
+            }
+
+            serial_specified = true;
+        }
+        else if (strcmp(av[0], "--format") == 0 || starts_with(av[0], "--format=")) {
+            const char * format;
+            if(strcmp(av[0], "--format") == 0) {
+                ac--;
+                av++;
+                if (ac < 1) return -1;
+                format = av[0];
+            }
+            else {
+                format = av[0] + strlen("--format=");
+            }
+
+            if (strcmp(format, "binary") == 0)
+                o->format = FLASH_FORMAT_BINARY;
+            else if (strcmp(format, "ihex") == 0)
+                o->format = FLASH_FORMAT_IHEX;
+            else
+                return -1;
+        }
+        else {
+            break;  // non-option found
+        }
+
+        ac--;
+        av++;
+    }
+
+    // command and (optional) device name
+
+    while(ac >= 1) { // looks like for stlinkv1 the device name and command may be swaped - check both positions in all cases
+        if (strcmp(av[0], "erase") == 0) {
+            if (o->cmd != FLASH_CMD_NONE) return -1;
+            o->cmd = FLASH_CMD_ERASE;
+        }
+        else if (strcmp(av[0], "read") == 0) {
+            if (o->cmd != FLASH_CMD_NONE) return -1;
+            o->cmd = FLASH_CMD_READ;
+        }
+        else if (strcmp(av[0], "write") == 0) {
+            if (o->cmd != FLASH_CMD_NONE) return -1;
+            o->cmd = FLASH_CMD_WRITE;
+        }
+        else if(starts_with(av[0], "/dev/")) {
+            if (o->devname) return -1;
+            o->devname = av[0];
+        }
+        else {
+            break;
+        }
+
+        ac--;
+        av++;
+    }
+
+    char * tail;
+    switch(o->cmd) {
+        case FLASH_CMD_NONE:     // no command found
+            return -1;
+
+        case FLASH_CMD_ERASE:    // no more arguments expected
+            if(ac != 0) return -1;
+            break;
+
+        case FLASH_CMD_READ:     // expect filename, addr and size
+            if (ac != 3) return -1;
+
+            o->filename = av[0];
+            o->addr = (uint32_t) strtoul(av[1], &tail, 16);
+            if(tail[0] != '\0') return -1;
+
+            o->size = strtoul(av[2], &tail, 16);
+            if(tail[0] != '\0') return -1;
+
+            break;
+
+        case FLASH_CMD_WRITE:
+            if(o->format == FLASH_FORMAT_BINARY) {    // expect filename and addr
+                if (ac != 2) return -1;
+
+                o->filename = av[0];
+                o->addr = (uint32_t) strtoul(av[1], &tail, 16);
+                if(tail[0] != '\0') return -1;
+            }
+            else if(o->format == FLASH_FORMAT_IHEX) { // expect filename
+                if (ac != 1) return -1;
+
+                o->filename = av[0];
+            }
+            else {
+                return -1;
+            }
+            break;
+    }
+
+    // some constistence checks
+    
+    if(serial_specified && o->devname != NULL) return -1; // serial not supported for v1
+
+    return 0;
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,3 +8,8 @@ foreach(test ${TESTS})
 	add_dependencies(${test} ${PROJECT_NAME})
 	target_link_libraries(${test} ${PROJECT_NAME})
 endforeach()
+
+add_executable(flash flash.c)
+add_dependencies(flash stflash)
+target_link_libraries(flash stflash)
+

--- a/tests/flash.c
+++ b/tests/flash.c
@@ -1,0 +1,111 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <stlink.h>
+#include <stlink/tools/flash.h>
+
+struct Test {
+    const char * cmd_line;
+    int res;
+    struct flash_opts opts;
+};
+
+static bool cmp_strings(const char * s1, const char * s2) {
+    if(s1 == NULL || s2 == NULL) return (s1 == s2);
+    else return (0 == strcmp(s1, s2));
+}
+
+static bool cmp_mem(const uint8_t * s1, const uint8_t * s2, size_t size) {
+    if(s1 == NULL || s2 == NULL) return (s1 == s2);
+    else return (0 == memcmp(s1, s2, size));
+}
+
+static bool execute_test(const struct Test * test) {
+    int ac = 0;
+    char* av[32];
+
+    // parse (tokenize) the test command line
+    char cmd_line[strlen(test->cmd_line)];
+    strcpy(cmd_line, test->cmd_line);
+
+    for(char * tok = strtok(cmd_line, " "); tok; tok = strtok(NULL, " ")) {
+        if((size_t)ac >= sizeof(av)/sizeof(av[0])) return false;
+
+        av[ac] = tok;
+        ++ac;
+    }
+
+    // call
+    struct flash_opts opts;
+    int res = flash_get_opts(&opts, ac, av);
+
+    // compare results
+    bool ret = (res == test->res);
+
+    if(ret && (res == 0)) {
+        ret &= (opts.cmd == test->opts.cmd);
+        ret &= cmp_strings(opts.devname, test->opts.devname);
+        ret &= cmp_mem(opts.serial, test->opts.serial, sizeof(opts.serial));
+        ret &= cmp_strings(opts.filename, test->opts.filename);
+        ret &= (opts.addr == test->opts.addr);
+        ret &= (opts.size == test->opts.size);
+        ret &= (opts.reset == test->opts.reset);
+        ret &= (opts.log_level == test->opts.log_level);
+        ret &= (opts.format == test->opts.format);
+    }
+
+    printf("[%s] (%d) %s\n", ret ? "OK" : "ERROR", res, test->cmd_line);
+    return ret;
+}
+
+struct Test tests[] = {
+    { "", -1, 
+        {} },
+    { "--debug --reset read /dev/sg0 test.bin 0x80000000 0x1000", 0,
+        { .cmd = FLASH_CMD_READ, .devname = "/dev/sg0", .serial = {}, .filename = "test.bin",
+          .addr = 0x80000000, .size = 0x1000, .reset = 1, .log_level = DEBUG_LOG_LEVEL, .format = FLASH_FORMAT_BINARY } },
+    { "--debug --reset write /dev/sg0 test.bin 0x80000000", 0,
+        { .cmd = FLASH_CMD_WRITE, .devname = "/dev/sg0", .serial = {}, .filename = "test.bin",
+          .addr = 0x80000000, .size = 0, .reset = 1, .log_level = DEBUG_LOG_LEVEL, .format = FLASH_FORMAT_BINARY } },
+    { "--serial A1020304 /dev/sg0 erase", -1,
+        {} },
+    { "/dev/sg0 erase", 0,
+        { .cmd = FLASH_CMD_ERASE, .devname = "/dev/sg0", .serial = {}, .filename = NULL,
+          .addr = 0, .size = 0, .reset = 0, .log_level = STND_LOG_LEVEL, .format = FLASH_FORMAT_BINARY } },
+    { "--debug --reset read test.bin 0x80000000 0x1000", 0,
+        { .cmd = FLASH_CMD_READ, .devname = NULL, .serial = {}, .filename = "test.bin",
+          .addr = 0x80000000, .size = 0x1000, .reset = 1, .log_level = DEBUG_LOG_LEVEL, .format = FLASH_FORMAT_BINARY } },
+    { "--debug --reset write test.bin 0x80000000", 0,
+        { .cmd = FLASH_CMD_WRITE, .devname = NULL, .serial = {}, .filename = "test.bin",
+          .addr = 0x80000000, .size = 0, .reset = 1, .log_level = DEBUG_LOG_LEVEL, .format = FLASH_FORMAT_BINARY } },
+    { "erase", 0,
+        { .cmd = FLASH_CMD_ERASE, .devname = NULL, .serial = {}, .filename = NULL,
+          .addr = 0, .size = 0, .reset = 0, .log_level = STND_LOG_LEVEL, .format = FLASH_FORMAT_BINARY } },
+    { "--debug --reset --format=ihex write test.hex", 0,
+        { .cmd = FLASH_CMD_WRITE, .devname = NULL, .serial = {}, .filename = "test.hex",
+          .addr = 0, .size = 0, .reset = 1, .log_level = DEBUG_LOG_LEVEL, .format = FLASH_FORMAT_IHEX } },
+    { "--debug --reset --format=binary write test.hex", -1,
+        {} },
+    { "--debug --reset --format=ihex write test.hex 0x80000000", -1,
+        {} },
+    { "--debug --reset write test.hex sometext", -1,
+        {} },
+    { "--serial A1020304 erase", 0,
+        { .cmd = FLASH_CMD_ERASE, .devname = NULL, .serial = "\0\0\0\0\0\0\0\0\xA1\x02\x03\x04", .filename = NULL,
+          .addr = 0, .size = 0, .reset = 0, .log_level = STND_LOG_LEVEL, .format = FLASH_FORMAT_BINARY } },
+    { "--serial=A1020304 erase", 0,
+        { .cmd = FLASH_CMD_ERASE, .devname = NULL, .serial = "\0\0\0\0\0\0\0\0\xA1\x02\x03\x04", .filename = NULL,
+          .addr = 0, .size = 0, .reset = 0, .log_level = STND_LOG_LEVEL, .format = FLASH_FORMAT_BINARY } },
+};
+
+int main()
+{
+    bool allOk = true;
+    for(size_t i = 0; i < sizeof(tests)/sizeof(tests[0]); ++i) {
+        if(!execute_test(&tests[i])) allOk = false;
+    }
+
+    return (allOk ? 0 : 1);
+}
+


### PR DESCRIPTION
Hi

here is my implementation of Intel-HEX format for st-flash (both reading and writing). The format can be selected with new command line option '--format=ihex' (one may not specify <addr> for write with the format, the address will be taken from input file).

Additionally I've re-designed the command line parsing, because it was too complicated with the new option. And added some unit-tests for parsing itself to guaranty all old options still work.

Unfortunately it's not so easy to split this pull request to single features, but I could try if you prefer.

WMBR,
dev26th