### PR TITLE
Do not issue JTAG reset on stlink-v1

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -880,7 +880,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[16
     }
 
     if (reset) {
-        stlink_jtag_reset(sl, 2);
+        if( sl->version.stlink_v > 1 ) stlink_jtag_reset(sl, 2);
         stlink_reset(sl);
         usleep(10000);
     }


### PR DESCRIPTION
This works around issue #480.  I'm not sure if it is the correct way to fix it.  It is tested and works here on a stlink-v1 board.