### PR TITLE
fix-482

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ MAKEFLAGS += -s
 
 all: release
 ci: lint debug release test
+install: install_release
 
 help:
 	@echo "      release: Run a release build"
@@ -41,5 +42,11 @@ build/Release:
 clean:
 	@echo "[CLEAN]"
 	@rm -Rf build
+
+install_release: release
+	@$(MAKE) -C build/Release install
+
+install_debug: debug
+	@$(MAKE) -C build/Debug install
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ $ make
 To build debian package you need debuild.
 
 ```
-$ git archive --prefix=$(git describe)/ HEAD | bzip2 --stdout > ../libstlink_$(sed -En -e "s/.*\((.*)\).*/\1/" -e "1,1 p" debian/changelog).orig.tar.bz2
 $ debuild -uc -us
 ```
 


### PR DESCRIPTION
Implement install delegate and use it in debian/rules.

Install of udev rules and modprobe config is still done in debian/rules.