### PR TITLE
Build debian package with more use of cmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ MAKEFLAGS += -s
 
 all: release
 ci: lint debug release test
+install: install_release
 
 help:
 	@echo "      release: Run a release build"
@@ -41,5 +42,11 @@ build/Release:
 clean:
 	@echo "[CLEAN]"
 	@rm -Rf build
+
+install_release: release
+	@$(MAKE) -C build/Release install
+
+install_debug: debug
+	@$(MAKE) -C build/Debug install
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ $ make
 To build debian package you need debuild.
 
 ```
-$ git archive --prefix=$(git describe)/ HEAD | bzip2 --stdout > ../libstlink_$(sed -En -e "s/.*\((.*)\).*/\1/" -e "1,1 p" debian/changelog).orig.tar.bz2
 $ debuild -uc -us
 ```
 

--- a/debian/libstlink-dev.install
+++ b/debian/libstlink-dev.install
@@ -1,3 +1,5 @@
 usr/include/*
 usr/lib/*/lib*.a
 usr/lib/*/pkgconfig/*
+usr/lib/*/lib*.so
+

--- a/debian/libstlink.install
+++ b/debian/libstlink.install
@@ -1,3 +1,3 @@
-usr/lib/*/lib*.so*
+usr/lib/*/lib*.so.*
 lib/udev/rules.d/*.rules
 lib/modprobe.d/*.conf

--- a/debian/rules
+++ b/debian/rules
@@ -22,12 +22,7 @@ include /usr/share/dpkg/default.mk
 	dh $@
 
 
-OUTDIR=build/Release
 ROOTDIR=debian/tmp
-DSTDIR=$(ROOTDIR)/usr
-BINDIR=$(DSTDIR)/bin
-SHAREDIR=$(DSTDIR)/share/stlink
-LIBDIR=$(DSTDIR)/lib/$(if $(DEB_TARGET_MULTIARCH),$(DEB_TARGET_MULTIARCH),$(DEB_BUILD_MULTIARCH))
 UDEVDIR=$(ROOTDIR)/lib/udev/rules.d/
 MODDIR=$(ROOTDIR)/lib/modprobe.d/
 
@@ -38,20 +33,12 @@ export CMAKEFLAGS = \
 
 override_dh_auto_configure:
 
+override_dh_auto_test:
+
 override_dh_auto_install:
-	install -d $(DSTDIR)/include/stlink/tools
-	install -d $(LIBDIR)/pkgconfig
-	install -d $(BINDIR)
-	install -d $(SHAREDIR)
+	dh_auto_install
 	install -d $(UDEVDIR)
 	install -d $(MODDIR)
-	install -m644 $(wildcard include/*.h) $(DSTDIR)/include
-	install -m644 $(wildcard include/stlink/*.h) $(DSTDIR)/include/stlink
-	install -m644 $(wildcard include/stlink/tools/*.h) $(DSTDIR)/include/stlink/tools
-	install -m755 $(wildcard $(OUTDIR)/st-* $(OUTDIR)/src/gdbserver/st-* $(OUTDIR)/src/tools/gui/stlink-gui*) $(BINDIR)
-	cp -d $(wildcard $(OUTDIR)/libstlink.*) $(LIBDIR)
-	install -m644 $(OUTDIR)/usr/lib/pkgconfig/stlink.pc $(LIBDIR)/pkgconfig
-	install -m644 src/tools/gui/stlink-gui.ui $(SHAREDIR)
 	install -m644 etc/udev/rules.d/*.rules $(UDEVDIR)
 	install -m644 etc/modprobe.d/*.conf $(MODDIR)
 

--- a/debian/rules
+++ b/debian/rules
@@ -19,24 +19,22 @@ include /usr/share/dpkg/default.mk
 
 # main packaging script based on dh7 syntax
 %:
-	dh $@
+	dh $@ --buildsystem cmake
 
 
 ROOTDIR=debian/tmp
 UDEVDIR=$(ROOTDIR)/lib/udev/rules.d/
 MODDIR=$(ROOTDIR)/lib/modprobe.d/
 
-export CMAKEFLAGS = \
-	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH) \
-	-DCMAKE_INSTALL_PREFIX=/usr \
-
 
 override_dh_auto_configure:
+	dh_auto_configure --buildsystem cmake -- \
+		-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
 override_dh_auto_test:
 
 override_dh_auto_install:
-	dh_auto_install
+	dh_auto_install --buildsystem cmake
 	install -d $(UDEVDIR)
 	install -d $(MODDIR)
 	install -m644 etc/udev/rules.d/*.rules $(UDEVDIR)

--- a/debian/stlink-gui.install
+++ b/debian/stlink-gui.install
@@ -1,2 +1,2 @@
 /usr/bin/stlink-gui*
-/usr/share/*
+/usr/share/stlink/*


### PR DESCRIPTION
* Make use of `dh --buildsystem cmake`, as suggested by nekromant.
* Keep install rules of module config and udev rules separate, to keep normal cmake install as documented.
* Move libstlink.so symlink to dev-package, provided by nekromant.