### PR TITLE
Add option to keep RPATH in installed binaries for local installs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(stlink C)
+
+option( INSTALL_STLINK_WITH_RPATH "Keep rpath in binaries/libraries after installing.  Useful for local installs to non-system paths." OFF )
+mark_as_advanced( INSTALL_STLINK_WITH_RPATH )
+if( INSTALL_STLINK_WITH_RPATH )
+  set( CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib )
+endif()
+
 set(PROJECT_DESCRIPTION "Open source version of the STMicroelectronics Stlink Tools")
 
 include(CheckIncludeFile)


### PR DESCRIPTION
Useful if you don't want to install to /usr/bin or similar, so that you don't have to maintain (DY)LD_LIBRARY_PATH.  Not recommended to do this on system installs, so the default is off.  I also marked it as advanced.