### PR TITLE
Fix install locations for modprobe config and udev rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ install(TARGETS st-flash st-info
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	file(GLOB RULES_FILES etc/udev/rules.d/*.rules)
 	install(FILES etc/modprobe.d/stlink_v1.conf
-	DESTINATION /etc)
+	DESTINATION /etc/modprobe.d/)
 	install(FILES ${RULES_FILES}
 	DESTINATION /lib/udev/rules.d/)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(stlink C)
 set(PROJECT_DESCRIPTION "Open source version of the STMicroelectronics Stlink Tools")
+set(STLINK_UDEV_RULES_DIR "/etc/udev/rules.d" CACHE PATH "Udev rules directory")
+set(STLINK_MODPROBED_DIR "/etc/modprobe.d" CACHE PATH "modprobe.d directory")
 
 option(STLINK_GENERATE_MANPAGES "Generate manpages with pandoc" OFF)
 
@@ -131,9 +133,9 @@ install(TARGETS st-flash st-info
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	file(GLOB RULES_FILES etc/udev/rules.d/*.rules)
 	install(FILES etc/modprobe.d/stlink_v1.conf
-	DESTINATION /etc/modprobe.d/)
+	DESTINATION ${STLINK_MODPROBED_DIR}/)
 	install(FILES ${RULES_FILES}
-	DESTINATION /lib/udev/rules.d/)
+	DESTINATION ${STLINK_UDEV_RULES_DIR}/)
 endif()
 
 add_subdirectory(src/gdbserver)

--- a/debian/rules
+++ b/debian/rules
@@ -24,4 +24,5 @@ include /usr/share/dpkg/default.mk
 # This is example for Cmake (See http://bugs.debian.org/641051 )
 override_dh_auto_configure:
 	dh_auto_configure -- \
-    -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
+    -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH) \
+    -DSTLINK_UDEV_RULES_DIR='/lib/udev/rules.d'

--- a/doc/compiling.md
+++ b/doc/compiling.md
@@ -79,3 +79,13 @@ brew install libusb cmake
 ```
 
 Compile as described in the first section of this document.
+
+## Build using different directories for udev and modprobe
+
+To put the udev or the modprobe configuration files into a different directory
+during installation you can use the following cmake options:
+
+```
+$ cmake -DSTLINK_UDEV_RULES_DIR="/usr/lib/udev/rules.d" \
+        -DSTLINK_MODPROBED_DIR="/usr/lib/modprobe.d" ..
+```


### PR DESCRIPTION
I had two problems while packing stlink for Arch Linux (this package: https://aur.archlinux.org/packages/stlink-git/):

1. The file `etc/modprobe.d/stlink_v1.conf` is installed to `/etc/stlink_v1.conf`. The subdirectory `modprobe.d` is not created. I'm quite sure that this is true for other distributions too. The first patch of the patch set should solve that.

2. The udev-rules are installed to the absolute location `/lib/udev/rules.d`. In Arch Linux, `/lib` is only a link to `/usr/lib`. To create a package, I have to be able to install the files to `/usr/lib`. To fix this, I just applied the `CMAKE_INSTALL_PREFIX` to this path too. I'm not sure if this is OK for other distributions too. Would it be better to use some other variable like `CMAKE_LIBRARY_PREFIX` instead?