### PR TITLE
add support for STM32F412

### DIFF
--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -46,6 +46,7 @@ enum stlink_stm32_chipids {
 	STLINK_CHIPID_STM32_F334             = 0x438,
 	STLINK_CHIPID_STM32_F3_SMALL         = 0x439,
 	STLINK_CHIPID_STM32_F0               = 0x440,
+	STLINK_CHIPID_STM32_F412             = 0x441,
 	STLINK_CHIPID_STM32_F09X             = 0x442,
 	STLINK_CHIPID_STM32_F0_SMALL         = 0x444,
 	STLINK_CHIPID_STM32_F04              = 0x445,

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -286,7 +286,19 @@ static const struct stlink_chipid_params devices[] = {
             .bootrom_base = 0x1fffec00,		// "System memory" starting address from Table 2
             .bootrom_size = 0xC00 		// "System memory" byte size in hex from Table 2
         },
-	{
+        {
+            // RM0402 document was used to find these parameters
+            // Table 4.
+            .chip_id = STLINK_CHIPID_STM32_F412,
+            .description = "F4 device",
+            .flash_type = STLINK_FLASH_TYPE_F4,
+            .flash_size_reg = 0x1FFF7A22,   // "Flash size data register" (pg1135)
+            .flash_pagesize = 0x4000,        // Table 5. Flash module organization ?
+            .sram_size = 0x40000,        // "SRAM" byte size in hex from Table 4
+            .bootrom_base = 0x1FFF0000,     // "System memory" starting address from Table 4
+            .bootrom_size = 0x7800       // "System memory" byte size in hex from Table 4
+        },
+        {
             .chip_id = STLINK_CHIPID_STM32_F09X,
             .description = "F09X device",
             .flash_type = STLINK_FLASH_TYPE_F0,

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -218,6 +218,7 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
 		sl->chip_id == STLINK_CHIPID_STM32_F4_DSI ||
 		sl->chip_id == STLINK_CHIPID_STM32_F410   ||
 		sl->chip_id == STLINK_CHIPID_STM32_F411RE ||
+		sl->chip_id == STLINK_CHIPID_STM32_F412   ||
 		sl->chip_id == STLINK_CHIPID_STM32_F446
 		) {
         if( sl->version.stlink_v == 1 ) {


### PR DESCRIPTION
General support for STM32F412 devices.
Added chipid, device params and fixed condition in flash_loader.c

Checked on 32F412GDISCOVERY kit board.