### PR TITLE
after 4c69cae257e317e9297f5a89eed940313b9c25c2 a compile produces the

### DIFF
--- a/src/sg.c
+++ b/src/sg.c
@@ -933,7 +933,8 @@ static stlink_backend_t _stlink_sg_backend = {
     _stlink_sg_step,
     _stlink_sg_current_mode,
     _stlink_sg_force_debug,
-    NULL
+    NULL, /* target_voltage */
+    NULL /* set_swdclk */
 };
 
 static stlink_t* stlink_open(const int verbose) {


### PR DESCRIPTION
following warning:
warning: missing initializer for field ‘set_swdclk’ of ‘stlink_backend_t
{aka struct _stlink_backend}’ [-Wmissing-field-initializers]

silence the warning and expand comment