### PR TITLE
serialnumber support  st-util and st-flash

### DIFF
--- a/src/tools/flash_opts.c
+++ b/src/tools/flash_opts.c
@@ -47,12 +47,13 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av)
 
             /** @todo This is not really portable, as strlen really returns size_t we need to obey and not cast it to a signed type. */
             int j = (int)strlen(serial);
+            int length = j / 2;  //the length of the destination-array
             if(j % 2 != 0) return -1;
  
             for(size_t k = 0; j >= 0 && k < sizeof(o->serial); ++k, j -= 2) {
                 char buffer[3] = {0};
                 memcpy(buffer, serial + j, 2);
-                o->serial[12 - k] = (uint8_t)strtol(buffer, NULL, 16);
+                o->serial[length - k] = (uint8_t)strtol(buffer, NULL, 16);
             }
 
             serial_specified = true;


### PR DESCRIPTION
modified serialnumbersupport in st-flash:
  in flash_opts take care of the length of the given serialnumber (was fix 12 chars)
added serialnumber support in st-util:
  implemented like in st-flash.