### PR TITLE
Fix incorrect release folder name in docs

### DIFF
--- a/doc/compiling.md
+++ b/doc/compiling.md
@@ -27,13 +27,13 @@ $ make
 You could install to a user folder e.g `$HOME`:
 
 ```
-$ cd release; make install DESTDIR=$HOME
+$ cd build/Release; make install DESTDIR=$HOME
 ```
 
 Or system wide:
 
 ```
-$ cd release; sudo make install
+$ cd build/Release; sudo make install
 ```
 
 ## Linux


### PR DESCRIPTION
This fixes a minor inconvenience in the documentations w.r.t. compiling from source; the directory where the build ends up has changed.