### PR TITLE
Fix compilation when path includes spaces

### DIFF
--- a/src/tools/gui/CMakeLists.txt
+++ b/src/tools/gui/CMakeLists.txt
@@ -9,13 +9,13 @@ include_directories(SYSTEM ${gtk_INCLUDE_DIRS})
 
 add_executable(stlink-gui-local ${GUI_SOURCES})
 set_target_properties(stlink-gui-local PROPERTIES
-                      COMPILE_FLAGS -DSTLINK_UI_DIR=\\"${CMAKE_CURRENT_SOURCE_DIR}/gui\\")
+                      COMPILE_DEFINITIONS STLINK_UI_DIR="${CMAKE_CURRENT_SOURCE_DIR}/gui")
 target_link_libraries(stlink-gui-local ${STLINK_LIB_STATIC} ${gtk_LDFLAGS})
 
 
 add_executable(stlink-gui ${GUI_SOURCES})
 set_target_properties(stlink-gui PROPERTIES
-                      COMPILE_FLAGS -DSTLINK_UI_DIR=\\"${CMAKE_INSTALL_PREFIX}/${INSTALLED_UI_DIR}\\")
+                      COMPILE_DEFINITIONS STLINK_UI_DIR="${CMAKE_INSTALL_PREFIX}/${INSTALLED_UI_DIR}")
 target_link_libraries(stlink-gui ${STLINK_LIB_STATIC} ${gtk_LDFLAGS})
 
 install(TARGETS stlink-gui


### PR DESCRIPTION
Currently compilation of `release` would break when the path to `stlink` included spaces. There seemed to be no proper way to fix this by escaping within `COMPILE_FLAGS`, but since CMake 3.0 there is a `COMPILE_DEFINITIONS` property that handles escaping itself.