### PR TITLE
Added --flash=n[k][m] command line option to override device model

### DIFF
--- a/doc/man/st-flash.1
+++ b/doc/man/st-flash.1
@@ -53,6 +53,14 @@ TODO
 TODO
 .RS
 .RE
+.TP
+.B --flash=\f[I]size\f[]
+Override the device's normal flash size, where size is the flash size in bytes. 
+It can be specified in decimal, octal or hexadecimal.
+The size argument can optionally be followed by 'k' for KB or 'm' for MB.
+Examples --flash=128k or --flash=0x080k.
+.RS
+.RE
 .SH EXAMPLES
 .PP
 Flash \f[C]firmware.bin\f[] to device

--- a/doc/man/st-flash.md
+++ b/doc/man/st-flash.md
@@ -49,6 +49,10 @@ reset
 --serial *iSerial*
 :   TODO
 
+--flash=fsize
+:   Where fsize is the size in decimal, octal, or hex followed by an optional multiplier 
+'k' for KB, or 'm' for MB.
+Use a leading "0x" to specify hexadecimal, or a leading zero for octal.
 
 # EXAMPLES
 Flash `firmware.bin` to device

--- a/include/stlink/tools/flash.h
+++ b/include/stlink/tools/flash.h
@@ -4,8 +4,6 @@
 #include <stdint.h>
 #include <stlink.h>
 
-#include <stlink/chipid.h>
-
 #define DEBUG_LOG_LEVEL 100
 #define STND_LOG_LEVEL  50
 
@@ -22,7 +20,7 @@ struct flash_opts
     int reset;
     int log_level;
     enum flash_format format;
-    uint32_t flash_size;	/* --flash=n[k][m] */
+    size_t flash_size;	/* --flash=n[k][m] */
 };
 
 #define FLASH_OPTS_INITIALIZER {0, NULL, {}, NULL, 0, 0, 0, 0, 0, 0 }

--- a/include/stlink/tools/flash.h
+++ b/include/stlink/tools/flash.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stlink.h>
 
+#include <stlink/chipid.h>
+
 #define DEBUG_LOG_LEVEL 100
 #define STND_LOG_LEVEL  50
 
@@ -20,9 +22,10 @@ struct flash_opts
     int reset;
     int log_level;
     enum flash_format format;
+    enum stlink_stm32_chipids chipid;
 };
 
-#define FLASH_OPTS_INITIALIZER {0, NULL, {}, NULL, 0, 0, 0, 0, 0 }
+#define FLASH_OPTS_INITIALIZER {0, NULL, {}, NULL, 0, 0, 0, 0, 0, 0 }
 
 int flash_get_opts(struct flash_opts* o, int ac, char** av);
 

--- a/include/stlink/tools/flash.h
+++ b/include/stlink/tools/flash.h
@@ -22,7 +22,7 @@ struct flash_opts
     int reset;
     int log_level;
     enum flash_format format;
-    enum stlink_stm32_chipids chipid;
+    uint32_t flash_size;	/* --flash=n[k][m] */
 };
 
 #define FLASH_OPTS_INITIALIZER {0, NULL, {}, NULL, 0, 0, 0, 0, 0, 0 }

--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -29,18 +29,15 @@ static void cleanup(int signum) {
 
 static void usage(void)
 {
-    puts("stlinkv1 command line: ./st-flash [--debug] [--reset] [--format <format>] [--chipid <chipid>] {read|write} /dev/sgX <path> <addr> <size>");
-    puts("stlinkv1 command line: ./st-flash [--debug] [--chipid <chipid>] /dev/sgX erase");
-    puts("stlinkv2 command line: ./st-flash [--debug] [--reset] [--serial <serial>] [--format <format>] [--chipid <chipid>] {read|write} <path> <addr> <size>");
-    puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] [--chipid <chipid>] erase");
-    puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] [--chipid <chipid>] reset");
+    puts("stlinkv1 command line: ./st-flash [--debug] [--reset] [--format <format>] [--flash=<fsize>] {read|write} /dev/sgX <path> <addr> <size>");
+    puts("stlinkv1 command line: ./st-flash [--debug] /dev/sgX erase");
+    puts("stlinkv2 command line: ./st-flash [--debug] [--reset] [--serial <serial>] [--format <format>] [--flash=<fsize>] {read|write} <path> <addr> <size>");
+    puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] erase");
+    puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] reset");
     puts("                       Use hex format for addr, <serial>, <chipid> and <size>.");
+    puts("                       fsize: Use decimal, octal or hex by prefix 0xXXX for hex, optionally followed by k=KB, or m=MB (eg. --flash=128k)");
     puts("                       Format may be 'binary' (default) or 'ihex', although <addr> must be specified for binary format only.");
     puts("                       ./st-flash [--version]");
-    puts("Note:");
-    printf("    --chipid=0x%04X is F1 medium density, 0x%04X is F1 high density\n",
-        STLINK_CHIPID_STM32_F1_MEDIUM,
-        STLINK_CHIPID_STM32_F1_HIGH);
 }
 
 int main(int ac, char** av)
@@ -68,10 +65,9 @@ int main(int ac, char** av)
     if (sl == NULL)
         return -1;
 
-    if ( (int)o.chipid != 0 ) {
-        if ( o.chipid == STLINK_CHIPID_STM32_F1_HIGH )
-            sl->flash_size = 128 * 1024;
-        printf("Forcing chipid 0x%04X with %uk flash.\n",o.chipid,(unsigned)(sl->flash_size)/1024u);
+    if ( o.flash_size != 0u && o.flash_size != sl->flash_size ) {
+        sl->flash_size = o.flash_size;
+        printf("Forcing flash size: --flash=0x%08zX\n",sl->flash_size);
     }
 
     sl->verbose = o.log_level;

--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -34,7 +34,7 @@ static void usage(void)
     puts("stlinkv2 command line: ./st-flash [--debug] [--reset] [--serial <serial>] [--format <format>] [--flash=<fsize>] {read|write} <path> <addr> <size>");
     puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] erase");
     puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] reset");
-    puts("                       Use hex format for addr, <serial>, <chipid> and <size>.");
+    puts("                       Use hex format for addr, <serial> and <size>.");
     puts("                       fsize: Use decimal, octal or hex by prefix 0xXXX for hex, optionally followed by k=KB, or m=MB (eg. --flash=128k)");
     puts("                       Format may be 'binary' (default) or 'ihex', although <addr> must be specified for binary format only.");
     puts("                       ./st-flash [--version]");

--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -29,14 +29,18 @@ static void cleanup(int signum) {
 
 static void usage(void)
 {
-    puts("stlinkv1 command line: ./st-flash [--debug] [--reset] [--format <format>] {read|write} /dev/sgX <path> <addr> <size>");
-    puts("stlinkv1 command line: ./st-flash [--debug] /dev/sgX erase");
-    puts("stlinkv2 command line: ./st-flash [--debug] [--reset] [--serial <serial>] [--format <format>] {read|write} <path> <addr> <size>");
-    puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] erase");
-    puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] reset");
-    puts("                       Use hex format for addr, <serial> and <size>.");
+    puts("stlinkv1 command line: ./st-flash [--debug] [--reset] [--format <format>] [--chipid <chipid>] {read|write} /dev/sgX <path> <addr> <size>");
+    puts("stlinkv1 command line: ./st-flash [--debug] [--chipid <chipid>] /dev/sgX erase");
+    puts("stlinkv2 command line: ./st-flash [--debug] [--reset] [--serial <serial>] [--format <format>] [--chipid <chipid>] {read|write} <path> <addr> <size>");
+    puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] [--chipid <chipid>] erase");
+    puts("stlinkv2 command line: ./st-flash [--debug] [--serial <serial>] [--chipid <chipid>] reset");
+    puts("                       Use hex format for addr, <serial>, <chipid> and <size>.");
     puts("                       Format may be 'binary' (default) or 'ihex', although <addr> must be specified for binary format only.");
     puts("                       ./st-flash [--version]");
+    puts("Note:");
+    printf("    --chipid=0x%04X is F1 medium density, 0x%04X is F1 high density\n",
+        STLINK_CHIPID_STM32_F1_MEDIUM,
+        STLINK_CHIPID_STM32_F1_HIGH);
 }
 
 int main(int ac, char** av)
@@ -63,6 +67,12 @@ int main(int ac, char** av)
 
     if (sl == NULL)
         return -1;
+
+    if ( (int)o.chipid != 0 ) {
+        if ( o.chipid == STLINK_CHIPID_STM32_F1_HIGH )
+            sl->flash_size = 128 * 1024;
+        printf("Forcing chipid 0x%04X with %uk flash.\n",o.chipid,(unsigned)(sl->flash_size)/1024u);
+    }
 
     sl->verbose = o.log_level;
 

--- a/src/tools/flash_opts.c
+++ b/src/tools/flash_opts.c
@@ -77,11 +77,29 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av)
             else
                 return -1;
         }
-	else if ( starts_with(av[0], "--chipid=") ) {
-		const char *arg = av[0] + strlen("--chipid=");
+	else if ( starts_with(av[0], "--flash=") ) {
+		const char *arg = av[0] + strlen("--flash=");
+		char *ep = 0;
 
-		o->chipid = (enum stlink_stm32_chipids)strtol(arg,0,0);
-        }
+		o->flash_size = (uint32_t)strtoul(arg,&ep,0);
+		while ( *ep ) {
+			switch ( *ep++ ) {
+			case 0:
+				break;
+			case 'k':
+			case 'K':
+				o->flash_size *= 1024u;
+				break;
+			case 'm':
+			case 'M':
+				o->flash_size *= 1024u * 1024u;
+				break;
+			default:
+				fprintf(stderr,"Invalid --flash=%s\n",arg);
+				return -1;
+			}
+		}
+	}
 	else {
             break;  // non-option found
         }

--- a/src/tools/flash_opts.c
+++ b/src/tools/flash_opts.c
@@ -77,7 +77,12 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av)
             else
                 return -1;
         }
-        else {
+	else if ( starts_with(av[0], "--chipid=") ) {
+		const char *arg = av[0] + strlen("--chipid=");
+
+		o->chipid = (enum stlink_stm32_chipids)strtol(arg,0,0);
+        }
+	else {
             break;  // non-option found
         }
 


### PR DESCRIPTION
By default, st-flash works the same as before (there is no more chipid override in this pull request).

Now _optionally_, you can specify **--flash=128k** for example, to override the stm32f103c8t6 to assume 128k of flash instead of the default of 64k. This option accepts decimal (128k), octal 0200k, or hex 0x80k. Obviously leaving the multiplier out is equally valid, for example: --flash=0x20000

The size may be followed by an _optional_ "**k**" or "**m**" to multiply the given value by 1024 or 1 Meg respectively.

Tests on the stm32f103c8t6 confirm that overriding the flash size is all that is required. I was still able to flash and read 128k without changing the chipid. I don't know if this will be true of all other devices but I suspect that they will.