### PR TITLE
Fix installation path for shared objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(stlink C)
 set(PROJECT_DESCRIPTION "Open source version of the STMicroelectronics Stlink Tools")
 set(STLINK_UDEV_RULES_DIR "/etc/udev/rules.d" CACHE PATH "Udev rules directory")
 set(STLINK_MODPROBED_DIR "/etc/modprobe.d" CACHE PATH "modprobe.d directory")
+set(STLINK_LIBRARY_PATH "lib/${CMAKE_LIBRARY_PATH}" CACHE PATH "Target lib directory")
 
 option(STLINK_GENERATE_MANPAGES "Generate manpages with pandoc" OFF)
 
@@ -108,7 +109,7 @@ else()
 endif()
 
 install(TARGETS ${STLINK_LIB_SHARED}
-	DESTINATION lib/${CMAKE_LIBRARY_PATH}
+	DESTINATION ${STLINK_LIBRARY_PATH}
 )
 
 ###
@@ -138,7 +139,7 @@ endif()
 set_target_properties(${STLINK_LIB_STATIC} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 
 install(TARGETS ${STLINK_LIB_STATIC}
-	ARCHIVE DESTINATION lib/${CMAKE_LIBRARY_PATH}
+	ARCHIVE DESTINATION ${STLINK_LIBRARY_PATH}
 )
 
 ###

--- a/usr/lib/pkgconfig/CMakeLists.txt
+++ b/usr/lib/pkgconfig/CMakeLists.txt
@@ -10,5 +10,5 @@ configure_file(
 )
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
-	DESTINATION lib/${CMAKE_LIBRARY_PATH}/pkgconfig/
+	DESTINATION ${STLINK_LIBRARY_PATH}/pkgconfig/
 )


### PR DESCRIPTION
There is no way to reliably configure installation path for shared
objects.  It looks like this should be configurable by setting
CMAKE_LIBRARY_PATH but this approach doesn't work as intended.
Moreover, according to cmake docs, purpose of this variable is slightly
different.
With this patch it should be possible to configure where all libs should
go by setting STLINK_LIBRARY_PATH to either /usr/lib or /usr/lib64
(/usr/lib64 is new default value assuming that most users run 64bit
systems).