### PR TITLE
skip GTK detection if we're cross-compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(cmake/CFlags.cmake)
 # Dependencies
 ###
 find_package(LibUSB REQUIRED)
-if (NOT APPLE AND NOT WIN32)
+if (NOT APPLE AND NOT WIN32 AND NOT CMAKE_CROSSCOMPILING)
 	find_package(PkgConfig)
 	pkg_check_modules(gtk gtk+-3.0)
 endif ()


### PR DESCRIPTION
It seems that stlink cannot use CMake's standard mechanism to find GTK3.
Cmake's GTK3 detection supports only Unix at the moment.

Therefore, stlink uses pkg-config to find GTK3. The downside of this is
that Cmake's cross-compiler settings are not taken into account. Even if
we're cross-compiling, CMake will find a local installation of GTK3 and
compilation of the GUI fails.

As a simple fix, we skip the GTK3 detection if we're cross-compiling.

(In the long run, we should use a more advanced mechanism to find GTK3.)