### PR TITLE
Added support for flashing second bank on STM32F10x_XL

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -83,7 +83,8 @@ extern "C" {
         STLINK_FLASH_TYPE_F0,
         STLINK_FLASH_TYPE_L0,
         STLINK_FLASH_TYPE_F4,
-        STLINK_FLASH_TYPE_L4
+        STLINK_FLASH_TYPE_L4,
+        STLINK_FLASH_TYPE_F1_XL,
     };
 
     struct stlink_reg {

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -255,7 +255,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             .chip_id = STLINK_CHIPID_STM32_F1_XL,
             .description = "F1 XL-density device",
-            .flash_type = STLINK_FLASH_TYPE_F0,
+            .flash_type = STLINK_FLASH_TYPE_F1_XL,
             .flash_size_reg = 0x1ffff7e0,
             .flash_pagesize = 0x800,
             .sram_size = 0x18000,


### PR DESCRIPTION
Some of the chips in the STM32F10x series has two separate flash banks. The first is always at most 512kB and the size of the second can be 0, 256 or 512 kB. For example, the STM32F103RF has 512 + 256 kB of flash memory. To be able to flash the second you need to use another set of registers instead of the usual SR/CR/AR registers. I made a patch for this that works for me(tm). Let me know if I should change anything; would be nice to get this included in upstream!
