### PR TITLE
Fix gitignore and add support for STM32L452

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+obj-*

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,10 @@
+.debhelper
+files
+debhelper-build-stamp
+*.log
+*.substvars
+libstlink-dev
+libstlink
+stlink-gui
+stlink-tools
+tmp

--- a/doc/tested-boards.md
+++ b/doc/tested-boards.md
@@ -34,7 +34,7 @@ STLink v2 (as found on the 32L and F4 Discovery boards), known working targets:
 
 STLink v2-1 (as found on the Nucleo boards), known working targets:
 
-* STM32F401xx (STM32 Nucleo-F401RE board) 
+* STM32F401xx (STM32 Nucleo-F401RE board)
 * STM32F030R8T6 (STM32 Nucleo-F030R8 board)
 * STM32F072RBT6 (STM32 Nucleo-F072RB board)
 * STM32F103RB (STM32 Nucleo-F103RB board)
@@ -46,6 +46,7 @@ STLink v2-1 (as found on the Nucleo boards), known working targets:
 * STM32F769NI (STM32F7 discovery board)
 * Nucleo-L152RE board
 * [Nucleo-L476RG board](http://www.st.com/en/evaluation-tools/nucleo-l476rg.html)
+* STM32L452RET6 (STM32 Nucleo-L452RE board)
 
 Please report any and all known working combinations so I can update this!
 

--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -34,7 +34,12 @@ enum stlink_stm32_chipids {
 	STLINK_CHIPID_STM32_F37x             = 0x432,
 	STLINK_CHIPID_STM32_F4_DE            = 0x433,
 	STLINK_CHIPID_STM32_F4_DSI           = 0x434,
+	/*
+	* 0x435 covers STM32L43xxx and STM32L44xxx devices
+	* 0x462 covers STM32L45xxx and STM32L46xxx devices
+	*/
 	STLINK_CHIPID_STM32_L43X             = 0x435,
+	STLINK_CHIPID_STM32_L46X             = 0x462,
 	/*
 	* 0x436 is actually assigned to some L1 chips that are called "Medium-Plus"
 	* and some that are called "High".  0x427 is assigned to the other "Medium-

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -430,19 +430,33 @@ static const struct stlink_chipid_params devices[] = {
             .bootrom_base = 0x1fff0000,      // Tables 4-6, pages 80-81 (Bank 1 system memory)
             .bootrom_size = 0x7000           // 28k (per bank), same source as base
         },
-	        {
-            // 	STLINK_CHIPID_STM32_L43X   
+        {
+            // STLINK_CHIPID_STM32_L43X
             // From RM0392.
- 	    .chip_id = STLINK_CHIPID_STM32_L43X,   
-            .description = "L43x device",
+            .chip_id = STLINK_CHIPID_STM32_L43X,
+            .description = "L43x/L44x device",
             .flash_type = STLINK_FLASH_TYPE_L4,
             .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (sec 43.2, page 1410)
             .flash_pagesize = 0x800,         // 2K (sec 3.2, page 74; also appears in sec 3.3.1 and tables 7-8 on pages 75-76)
             // SRAM1 is "up to" 64k in the standard Cortex-M memory map;
-            // SRAM2 is 16k mapped at at 0x10000000 (sec 2.3, page 73 for
+            // SRAM2 is 16k mapped at 0x10000000 (sec 2.3, page 73 for
             // sizes; table 2, page 74 for SRAM2 location)
             .sram_size = 0xc000,
             .bootrom_base = 0x1fff0000,      // Tables 4-6, pages 80-81 (Bank 1 system memory)
+            .bootrom_size = 0x7000           // 28k (per bank), same source as base
+        },
+        {
+            // STLINK_CHIPID_STM32_L46X
+            // From RM0394 (updated version of RM0392?).
+            .chip_id = STLINK_CHIPID_STM32_L46X,
+            .description = "L45x/46x device",
+            .flash_type = STLINK_FLASH_TYPE_L4,
+            .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (sec 45.2, page 1463)
+            .flash_pagesize = 0x800,         // 2K (sec 3.2, page 73; also appears in sec 3.3.1 and tables 7 on pages 73-74)
+            // SRAM1 is 128k at 0x20000000;
+            // SRAM2 is 32k mapped at 0x10000000 (sec 2.4.2, table 3-4, page 68, also fig 2 on page 63)
+            .sram_size = 0x20000,
+            .bootrom_base = 0x1fff0000,      // Tables 6, pages 71-72 (Bank 1 system memory, also fig 2 on page 63)
             .bootrom_size = 0x7000           // 28k (per bank), same source as base
         },
         {

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -304,7 +304,8 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
         loader_code = loader_code_stm32f0;
         loader_size = sizeof(loader_code_stm32f0);
     } else if ((sl->chip_id == STLINK_CHIPID_STM32_L4) ||
-	       (sl->chip_id == STLINK_CHIPID_STM32_L43X))
+              (sl->chip_id == STLINK_CHIPID_STM32_L43X) ||
+              (sl->chip_id == STLINK_CHIPID_STM32_L46X))
       {
         loader_code = loader_code_stm32l4;
         loader_size = sizeof(loader_code_stm32l4);


### PR DESCRIPTION
Unfortunately, I crammed 2 commits into this PR. The first deals with temporary files generated by `dpkg-buildpackage` on Debian stretch. The second should fix #603.