### PR TITLE
Add support of STM32L496xx/4A6xx devices

### DIFF
--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -36,9 +36,11 @@ enum stlink_stm32_chipids {
 	STLINK_CHIPID_STM32_F4_DSI           = 0x434,
 	/*
 	* 0x435 covers STM32L43xxx and STM32L44xxx devices
+	* 0x461 covers STM32L496xx and STM32L4A6xx devices
 	* 0x462 covers STM32L45xxx and STM32L46xxx devices
 	*/
 	STLINK_CHIPID_STM32_L43X             = 0x435,
+	STLINK_CHIPID_STM32_L496X            = 0x461,
 	STLINK_CHIPID_STM32_L46X             = 0x462,
 	/*
 	* 0x436 is actually assigned to some L1 chips that are called "Medium-Plus"

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -446,6 +446,20 @@ static const struct stlink_chipid_params devices[] = {
             .bootrom_size = 0x7000           // 28k (per bank), same source as base
         },
         {
+            // STLINK_CHIPID_STM32_L496X
+            // Support based on en.DM00083560.pdf (RM0351) document rev 5.
+            .chip_id = STLINK_CHIPID_STM32_L496X,
+            .description = "L496x/L4A6x device",
+            .flash_type = STLINK_FLASH_TYPE_L4,
+            .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (sec 49.2, page 1809)
+            .flash_pagesize = 0x800,         // Page erase (2 Kbyte) (sec 3.2, page 93)
+            // SRAM1 is 256k at 0x20000000
+            // SRAM2 is 64k at 0x20040000 (sec 2.2.1, fig 2, page 74)
+            .sram_size = 0x40000,            // Embedded SRAM (sec 2.4, page 84)
+            .bootrom_base = 0x1fff0000,      // System Memory (Bank 1) (sec 3.3.1)
+            .bootrom_size = 0x7000           // 28k (per bank), same source as base
+        },
+        {
             // STLINK_CHIPID_STM32_L46X
             // From RM0394 (updated version of RM0392?).
             .chip_id = STLINK_CHIPID_STM32_L46X,

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -305,7 +305,8 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
         loader_size = sizeof(loader_code_stm32f0);
     } else if ((sl->chip_id == STLINK_CHIPID_STM32_L4) ||
               (sl->chip_id == STLINK_CHIPID_STM32_L43X) ||
-              (sl->chip_id == STLINK_CHIPID_STM32_L46X))
+              (sl->chip_id == STLINK_CHIPID_STM32_L46X) ||
+	       (sl->chip_id == STLINK_CHIPID_STM32_L496X))
       {
         loader_code = loader_code_stm32l4;
         loader_size = sizeof(loader_code_stm32l4);


### PR DESCRIPTION
Hi,

I quickly added the support of my STM32L496G (discover) in stlink.

I can read and write data to the micro-controller memory. I think all is good.

Before write to the flash, I do a mass erase otherwise it fails with this message:

> 2017-07-14T15:48:32 ERROR src/common.c: Verification of flash failed at offset: 6144

Regards,
Anthony V.
