### PR TITLE
Fix verification of flash error for STM32L496x device (#617)

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1484,7 +1484,10 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
         unlock_flash_if(sl);
 
         /* select the page to erase */
-        if (sl->chip_id == STLINK_CHIPID_STM32_L4 || sl->chip_id == STLINK_CHIPID_STM32_L43X) {
+        if ((sl->chip_id == STLINK_CHIPID_STM32_L4) ||
+            (sl->chip_id == STLINK_CHIPID_STM32_L43X) ||
+            (sl->chip_id == STLINK_CHIPID_STM32_L46X) ||
+            (sl->chip_id == STLINK_CHIPID_STM32_L496X)) {
             // calculate the actual bank+page from the address
             uint32_t page = calculate_L4_page(sl, flashaddr);
 
@@ -1859,8 +1862,10 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
 
         /* TODO: Check that Voltage range is 2.7 - 3.6 V */
         if ((sl->chip_id != STLINK_CHIPID_STM32_L4) &&
-	    (sl->chip_id != STLINK_CHIPID_STM32_L43X))
-	  {
+            (sl->chip_id != STLINK_CHIPID_STM32_L43X) &&
+            (sl->chip_id != STLINK_CHIPID_STM32_L46X) &&
+            (sl->chip_id != STLINK_CHIPID_STM32_L496X)) {
+
             if( sl->version.stlink_v == 1 ) {
                 printf("STLINK V1 cannot read voltage, defaulting to 32-bit writes on F4 devices\n");
                 write_flash_cr_psiz(sl, 2);

--- a/src/gdbserver/gdb-server.c
+++ b/src/gdbserver/gdb-server.c
@@ -518,7 +518,10 @@ char* make_memory_map(stlink_t *sl) {
                 (unsigned int)sl->sram_size,
                 (unsigned int)sl->flash_size - 0x20000,
                 (unsigned int)sl->sys_base, (unsigned int)sl->sys_size);
-    } else if(sl->chip_id==STLINK_CHIPID_STM32_L4) {
+    } else if((sl->chip_id==STLINK_CHIPID_STM32_L4) ||
+              (sl->chip_id==STLINK_CHIPID_STM32_L43X) ||
+              (sl->chip_id==STLINK_CHIPID_STM32_L46X) ||
+              (sl->chip_id==STLINK_CHIPID_STM32_L496X)) {
         snprintf(map, sz, memory_map_template_L4,
                 (unsigned int)sl->flash_size, (unsigned int)sl->flash_size);
     } else {


### PR DESCRIPTION
There were missing chipid checks of STM32L496xx and STM32L46x devices.