### PR TITLE
Avoid array-out-of-bounds when building in sourcedir subdir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ endif()
 # fixup __FILE__ absolute paths in logging module
 # see: https://cmake.org/pipermail/cmake-developers/2015-January/024202.html
 string(LENGTH "${CMAKE_SOURCE_DIR}/" CMAKE_SOURCE_DIR_LENGTH)
-add_definitions(-DCMAKE_SOURCE_DIR_LENGTH=${CMAKE_SOURCE_DIR_LENGTH})
 
 set(STLINK_HEADERS
 	include/stlink.h
@@ -68,6 +67,8 @@ set(STLINK_SOURCE
 	src/logging.c
 	src/flash_loader.c
 )
+
+set_source_files_properties( src/logging.c PROPERTIES COMPILE_FLAGS "-DCMAKE_SOURCE_DIR=\"${CMAKE_SOURCE_DIR}\" -DCMAKE_BINARY_DIR=\"${CMAKE_BINARY_DIR}\"")
 
 if (WIN32 OR MSYS OR MINGW)
 	set (STLINK_SOURCE "${STLINK_SOURCE};src/mmap.c;src/mingw/mingw.c")

--- a/include/stlink/logging.h
+++ b/include/stlink/logging.h
@@ -23,7 +23,7 @@ int ugly_log(int level, const char *tag, const char *format, ...);
 #ifndef CMAKE_SOURCE_DIR_LENGTH
 #define CMAKE_SOURCE_DIR_LENGTH 0
 #endif
-#define UGLY_LOG_FILE (__FILE__+CMAKE_SOURCE_DIR_LENGTH)
+#define UGLY_LOG_FILE __FILE__
 
 /** @todo we need to write this in a more generic way, for now this should compile
  on visual studio (See http://stackoverflow.com/a/8673872/1836746) */

--- a/src/logging.c
+++ b/src/logging.c
@@ -8,13 +8,37 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <time.h>
+#include <string.h>
 
 #include "stlink/logging.h"
 
 static int max_level = UINFO;
 
+#define TOSTR(s) #s
+#define STR(s) TOSTR(s)
+
+static const char* source_dir = STR(CMAKE_SOURCE_DIR);
+static const char* build_dir = STR(CMAKE_BINARY_DIR);
+static int tagskip = 0;
+
 int ugly_init(int maximum_threshold) {
     max_level = maximum_threshold;
+    tagskip = 0;
+
+    // If build_dir is a subdir of source_dir
+   	if (strstr(build_dir, source_dir) != 0) {
+   	   	int len = strlen(source_dir);
+   	   	if (build_dir[len] == '/') {
+   	   	   	for (unsigned idx=len; idx<strlen(build_dir); idx++) {
+   	   	   	   	if (build_dir[idx] == '/')
+   	   	   	   	   	tagskip += 3; // "../"
+   	   	   	}
+   	   	}
+   	}
+
+   	// Then build_dir is not a subdir
+   	if (tagskip == 0)
+   	   	tagskip = strlen(source_dir) + 1;
     return 0;
 }
 
@@ -22,6 +46,7 @@ int ugly_log(int level, const char *tag, const char *format, ...) {
     if (level > max_level) {
         return 0;
     }
+    tag += tagskip;
     va_list args;
     va_start(args, format);
     time_t mytt = time(NULL);


### PR DESCRIPTION
The type of errors avoided looks like this.

../src/common.c:2250:9: bemærk: in expansion of macro »ILOG«
         ILOG("Ignoring %d bytes of 0x%02x at end of file\n", num_empty, erased_pattern);
         ^~~~