### PR TITLE
minor formatting fix in FAQ section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ enough unused registers. In my experience, -O3 causes that frequently.
 
 Q: At some point I use GDB command `next', and it hangs.
 
-A: Sometimes when you will try to use GDB `next' command to skip a loop,
+A: Sometimes when you will try to use GDB `next` command to skip a loop,
 it will use a rather inefficient single-stepping way of doing that.
-Set up a breakpoint manually in that case and do `continue'.
+Set up a breakpoint manually in that case and do `continue`.
 
 Q: Load command does not work in GDB.
 


### PR DESCRIPTION
was just single quotes instead of back ticks

This is pretty self explanatory.  It just irked me when I opened your readme, sorry if this PR doesn't follow a template I just did this real quick