### PR TITLE
fix write for microcontroler with RAM size less or equal to 32K

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1899,8 +1899,9 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         /* set programming mode */
         set_flash_cr_pg(sl);
 
+		size_t buf_size = (sl->sram_size > 0x8000) ? 0x8000 : 0x4000;
         for(off = 0; off < len;) {
-            size_t size = len - off > 0x8000 ? 0x8000 : len - off;
+            size_t size = len - off > buf_size ? buf_size : len - off;
 
             printf("size: %u\n", (unsigned int)size);
 


### PR DESCRIPTION
This fix is due to a problem to flash STM32F410 with large .bin (for example nuttx.bin). The result is :
st-flash 1.4.0-8-g1700e6a
2017-09-16T17:15:20 INFO src/common.c: Loading device parameters....
2017-09-16T17:15:20 INFO src/common.c: Device connected is: F410 device, id 0x10006458
2017-09-16T17:15:20 INFO src/common.c: SRAM size: 0x8000 bytes (32 KiB), Flash: 0x20000 bytes (128 KiB) in pages of 16384 bytes
2017-09-16T17:15:20 INFO src/common.c: Attempting to write 57728 (0xe180) bytes to stm32 address: 134217728 (0x8000000)
Flash page at addr: 0x0800c000 erasedEraseFlash - Sector:0x3 Size:0x4000 
2017-09-16T17:15:21 INFO src/common.c: Finished erasing 4 pages of 16384 (0x4000) bytes
2017-09-16T17:15:21 INFO src/common.c: Starting Flash write for F2/F4/L4
2017-09-16T17:15:21 INFO src/flash_loader.c: Successfully loaded flash loader in sram
enabling 32-bit flash writes
size: 32768
2017-09-16T17:15:24 ERROR src/flash_loader.c: flash loader run error
2017-09-16T17:15:24 ERROR src/common.c: stlink_flash_loader_run(0x8000000) failed! == -1
stlink_fwrite_flash() == -1

This issue is related to the buffer size : in src/common.c this size is fixed to 32KB.
To be able to use this size the target needs to have a RAM greater this value.
Indeed the flash loader is located at the begin of the RAM, on F4, it is written in SRAM at 0x2000000 and use 36b, then fl->buf_addr is fixed to 0x20000024.

For a F410RB with 32KB of RAM it's consequently not possible to load a buffer with the default size.

This patch check if the target has at least 32KB of RAM. If not the size is divided by 2.