### PR TITLE
Fix memory map for stm32l496xx boards.

### DIFF
--- a/src/gdbserver/gdb-server.c
+++ b/src/gdbserver/gdb-server.c
@@ -433,6 +433,25 @@ static const char* const memory_map_template_L4 =
     "  <memory type=\"rom\" start=\"0x1ffff800\" length=\"0x10\"/>"         // option byte area
     "</memory-map>";
 
+static const char* const memory_map_template_L496 =
+    "<?xml version=\"1.0\"?>"
+    "<!DOCTYPE memory-map PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
+    "     \"http://sourceware.org/gdb/gdb-memory-map.dtd\">"
+    "<memory-map>"
+    "  <memory type=\"rom\" start=\"0x00000000\" length=\"0x%x\"/>"        // code = sram, bootrom or flash; flash is bigger
+    "  <memory type=\"ram\" start=\"0x10000000\" length=\"0x10000\"/>"      // SRAM2 (64 KB)
+    "  <memory type=\"ram\" start=\"0x20000000\" length=\"0x40000\"/>"      // SRAM1 (256 KB)
+    "  <memory type=\"flash\" start=\"0x08000000\" length=\"0x%x\">"
+    "    <property name=\"blocksize\">0x800</property>"
+    "  </memory>"
+    "  <memory type=\"ram\" start=\"0x40000000\" length=\"0x1fffffff\"/>"   // peripheral regs
+    "  <memory type=\"ram\" start=\"0x60000000\" length=\"0x7fffffff\"/>"   // AHB3 Peripherals
+    "  <memory type=\"ram\" start=\"0xe0000000\" length=\"0x1fffffff\"/>"   // cortex regs
+    "  <memory type=\"rom\" start=\"0x1fff0000\" length=\"0x7000\"/>"       // bootrom
+    "  <memory type=\"rom\" start=\"0x1fff7800\" length=\"0x10\"/>"         // option byte area
+    "  <memory type=\"rom\" start=\"0x1ffff800\" length=\"0x10\"/>"         // option byte area
+    "</memory-map>";
+
 static const char* const memory_map_template =
     "<?xml version=\"1.0\"?>"
     "<!DOCTYPE memory-map PUBLIC \"+//IDN gnu.org//DTD GDB Memory Map V1.0//EN\""
@@ -520,9 +539,11 @@ char* make_memory_map(stlink_t *sl) {
                 (unsigned int)sl->sys_base, (unsigned int)sl->sys_size);
     } else if((sl->chip_id==STLINK_CHIPID_STM32_L4) ||
               (sl->chip_id==STLINK_CHIPID_STM32_L43X) ||
-              (sl->chip_id==STLINK_CHIPID_STM32_L46X) ||
-              (sl->chip_id==STLINK_CHIPID_STM32_L496X)) {
+              (sl->chip_id==STLINK_CHIPID_STM32_L46X)) {
         snprintf(map, sz, memory_map_template_L4,
+                (unsigned int)sl->flash_size, (unsigned int)sl->flash_size);
+    } else if(sl->chip_id==STLINK_CHIPID_STM32_L496X) {
+        snprintf(map, sz, memory_map_template_L496,
                 (unsigned int)sl->flash_size, (unsigned int)sl->flash_size);
     } else {
         snprintf(map, sz, memory_map_template,


### PR DESCRIPTION
STM32l496xx boards had incorrect configuration of the memory map, making memory inaccessible inside GDB.

To see the fix is right, take a look at http://www.st.com/content/ccc/resource/technical/document/reference_manual/02/35/09/0c/4f/f7/40/03/DM00083560.pdf/files/DM00083560.pdf/jcr:content/translations/en.DM00083560.pdf section **2.6.2 Boot configuration for STM32L496xx/4A6xx devices** table 7.