### PR TITLE
add unknown chip dummy

### DIFF
--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -11,6 +11,8 @@ extern "C" {
  * stm32 chipids, only lower 12 bits..
  */
 enum stlink_stm32_chipids {
+	STLINK_CHIPID_UNKNOWN                = 0x000,
+
 	STLINK_CHIPID_STM32_F1_MEDIUM        = 0x410,
 	STLINK_CHIPID_STM32_F2               = 0x411,
 	STLINK_CHIPID_STM32_F1_LOW           = 0x412,

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -484,6 +484,17 @@ static const struct stlink_chipid_params devices[] = {
             .bootrom_base = 0x1ff00000,
             .bootrom_size = 0x2000
         },
+        {
+            // unknown
+            .chip_id = STLINK_CHIPID_UNKNOWN,
+            .description = "unknown device",
+            .flash_type = STLINK_FLASH_TYPE_UNKNOWN,
+            .flash_size_reg = 0x0,
+            .flash_pagesize = 0x0,
+            .sram_size = 0x0,
+            .bootrom_base = 0x0,
+            .bootrom_size = 0x0
+        },
 
 
  };

--- a/src/common.c
+++ b/src/common.c
@@ -644,7 +644,8 @@ int stlink_load_device_params(stlink_t *sl) {
 
     if (params->flash_type == STLINK_FLASH_TYPE_UNKNOWN) {
         WLOG("Invalid flash type, please check device declaration\n");
-        return -1;
+        sl->flash_size = 0;
+        return 0;
     }
 
     // These are fixed...


### PR DESCRIPTION
The reason for my proposal of adding a dummy for the unknown chip is that I wanted to obtain the serial of the ST-link by a call to `st-info --probe`. This returns nothing (not even a warning) when an unknown chip is attached (in my case an NXP lpc17xx). With the changes here, I could easily obtain the serial, which I needed in OpenOCD, as multiple programmers are attached. (BTW: Although not supported, I am able to flash the chip, mentioned above)