### PR TITLE
debian/triggers: add (to run ldconfig)

### DIFF
--- a/debian/triggers
+++ b/debian/triggers
@@ -1,0 +1,1 @@
+activate-noawait ldconfig


### PR DESCRIPTION
After installing the deb package, st-util fails to start:

> $ st-util
> st-util: error while loading shared libraries: libstlink-shared.so.1: cannot open shared object file: No such file or directory

The reason is, no one ran `ldconfig` upon installing the library.

The solution, as per latest Debian recommendations [1], is to add an ldconfig trigger in `debian/triggers`, which is what this commit does.

[1] https://www.debian.org/doc/debian-policy/#ldconfig