### PR TITLE
rename STLINK_CHIPID_STM32_L4R9 to STLINK_CHIPID_STM32_L4RX

### DIFF
--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -68,7 +68,7 @@ enum stlink_stm32_chipids {
 	STLINK_CHIPID_STM32_L011             = 0x457,
 	STLINK_CHIPID_STM32_F410             = 0x458,
 	STLINK_CHIPID_STM32_F413             = 0x463,
-	STLINK_CHIPID_STM32_L4R9             = 0x470 // taken from the STM32L4R9I-DISCO board
+	STLINK_CHIPID_STM32_L4RX             = 0x470 // taken from the STM32L4R9I-DISCO board
 };
 
 /**

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -10,8 +10,8 @@ static const struct stlink_chipid_params devices[] = {
             .flash_size_reg = 0x1ff0f442,      // section 45.2
             .flash_pagesize = 0x800,           // No flash pages
             .sram_size = 0x80000,              // "SRAM" byte size in hex from
-            .bootrom_base = 0x00200000,        //! "System memory" starting address from 
-            .bootrom_size = 0xEDC0             //! @todo "System memory" byte size in hex from 
+            .bootrom_base = 0x00200000,        //! "System memory" starting address from
+            .bootrom_size = 0xEDC0             //! @todo "System memory" byte size in hex from
         },
         {
             //RM0385 and DS10916 document was used to find these paramaters
@@ -442,10 +442,10 @@ static const struct stlink_chipid_params devices[] = {
             .bootrom_size = 0x7000           // 28k (per bank), same source as base
         },
         {
-            // STM32L4R9 (maybe others in the L4Rx series too)
+            // STM32L4RX
             // From DM00310109.pdf
-            .chip_id = STLINK_CHIPID_STM32_L4R9,
-            .description = "L4R9 device",
+            .chip_id = STLINK_CHIPID_STM32_L4RX,
+            .description = "L4Rx device",
             .flash_type = STLINK_FLASH_TYPE_L4,
             .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (sec 52.2, page 2049)
             .flash_pagesize = 0x1000,        // 4k, section 3.3, pg 97

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -219,7 +219,7 @@ int stlink_flash_loader_init(stlink_t *sl, flash_loader_t *fl)
 	return 0;
 }
 
-static int loader_v_dependent_assignment(stlink_t *sl, 
+static int loader_v_dependent_assignment(stlink_t *sl,
                                          const uint8_t **loader_code, size_t *loader_size,
                                          const uint8_t *high_v_loader, size_t high_v_loader_size,
                                          const uint8_t *low_v_loader, size_t low_v_loader_size)
@@ -236,7 +236,7 @@ static int loader_v_dependent_assignment(stlink_t *sl,
         if (voltage == -1) {
             retval = -1;
             printf("Failed to read Target voltage\n");
-        } 
+        }
         else {
             if (voltage > 2700) {
                 *loader_code = high_v_loader;
@@ -306,7 +306,7 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
     } else if ((sl->chip_id == STLINK_CHIPID_STM32_L4) ||
               (sl->chip_id == STLINK_CHIPID_STM32_L43X) ||
               (sl->chip_id == STLINK_CHIPID_STM32_L46X) ||
-              (sl->chip_id == STLINK_CHIPID_STM32_L4R9) ||
+              (sl->chip_id == STLINK_CHIPID_STM32_L4RX) ||
 	            (sl->chip_id == STLINK_CHIPID_STM32_L496X))
       {
         loader_code = loader_code_stm32l4;


### PR DESCRIPTION
STM32L4R5ZI uses the same chip id, the reference manual (DM00310109.pdf) is the same for all L4Rxxxx devices.