### PR TITLE
Fix of build errors for Debian Stretch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 if (WIN32)
     set(STLINK_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} CACHE PATH "Target lib directory")
 else()
-    set(STLINK_LIBRARY_PATH "${LIB_INSTALL_DIR}/${CMAKE_LIBRARY_PATH}" CACHE PATH "Target lib directory")
+    set(STLINK_LIBRARY_PATH "${LIB_INSTALL_DIR}" CACHE PATH "Target lib directory")
 endif(WIN32)
 
 option(STLINK_GENERATE_MANPAGES "Generate manpages with pandoc" OFF)

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -5,6 +5,7 @@ debhelper-build-stamp
 *.substvars
 libstlink-dev
 libstlink
+libstlink1
 stlink-gui
 stlink-tools
 tmp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+stlink (1.5.0~joede9+1) stretch-backports; urgency=medium
+
+  * Ported for stretch-experimental. Some of the debian/*.install
+    files doesn't work as expected. I had to remove some
+    unnecessary pathes from some CMakelist.txt files.
+
+ -- Joerg Desch <debian@jdesch.de>  Wed, 11 Apr 2018 16:34:24 +0200
+
 stlink (1.5.0) unstable; urgency=medium
 
   [ Jerry Jacobs ]

--- a/debian/libstlink-dev.install
+++ b/debian/libstlink-dev.install
@@ -1,5 +1,5 @@
 usr/include/*
-usr/lib/*/lib*.a
-usr/lib/*/pkgconfig/*
-usr/lib/*/lib*.so
+usr/lib/libstlink*.a
+usr/lib/pkgconfig/*
+#usr/lib/libstlink*.so
 

--- a/debian/libstlink1.install
+++ b/debian/libstlink1.install
@@ -1,1 +1,1 @@
-usr/lib/*/lib*.so.*
+usr/lib/libstlink*.so*

--- a/debian/stlink-gui.install
+++ b/debian/stlink-gui.install
@@ -1,2 +1,2 @@
-/usr/bin/stlink-gui*
-/usr/share/stlink/stlink-gui.ui
+usr/bin/stlink-gui*
+usr/share/stlink/stlink-gui.ui

--- a/debian/stlink-tools.install
+++ b/debian/stlink-tools.install
@@ -1,3 +1,3 @@
-/usr/bin/st-*
+usr/bin/st-*
 lib/udev/rules.d/*.rules
 etc/modprobe.d/*.conf

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,8 +7,8 @@ file(GLOB STLINK_HEADERS
 	"${CMAKE_BINARY_DIR}/include/stlink/*.h"
 )
 install(FILES ${CMAKE_SOURCE_DIR}/include/stlink.h
-	DESTINATION include/${CMAKE_LIBRARY_PATH}
+	DESTINATION include
 )
 install(FILES ${STLINK_HEADERS}
-	DESTINATION include/${CMAKE_LIBRARY_PATH}/stlink
+	DESTINATION include/stlink
 )


### PR DESCRIPTION
Since I have to start using STM32 MCUs, I've built Debian packages out of your sources. There were some errors which I have fixed. As a result of these fixes, I have working Debian packages which I can install. I haven't had the time and hardware to test the code!

This PR should fix the issue #700.

Note: the entry in `debian/Changelog` is not what you need. ;-)