### PR TITLE
send memory map for STM32F411RE

### DIFF
--- a/src/gdbserver/gdb-server.c
+++ b/src/gdbserver/gdb-server.c
@@ -522,7 +522,7 @@ char* make_memory_map(stlink_t *sl) {
     char* map = malloc(sz);
     map[0] = '\0';
 
-    if(sl->chip_id==STLINK_CHIPID_STM32_F4 || sl->chip_id==STLINK_CHIPID_STM32_F446) {
+    if(sl->chip_id==STLINK_CHIPID_STM32_F4 || sl->chip_id==STLINK_CHIPID_STM32_F446 || sl->chip_id==STLINK_CHIPID_STM32_F411RE) {
         strcpy(map, memory_map_template_F4);
     } else if(sl->chip_id==STLINK_CHIPID_STM32_F4_DE) {
         strcpy(map, memory_map_template_F4_DE);


### PR DESCRIPTION
I was having trouble loading .elf files for the Multitech mDot using the default memory map. 

Thanks!
Dacoda Strack