### PR TITLE
Fixed flash memory map for F72XXX chip_id

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1451,7 +1451,7 @@ uint32_t calculate_L4_page(stlink_t *sl, uint32_t flashaddr) {
 uint32_t stlink_calculate_pagesize(stlink_t *sl, uint32_t flashaddr){
     if ((sl->chip_id == STLINK_CHIPID_STM32_F2) || (sl->chip_id == STLINK_CHIPID_STM32_F4) || (sl->chip_id == STLINK_CHIPID_STM32_F4_DE) ||
             (sl->chip_id == STLINK_CHIPID_STM32_F4_LP) || (sl->chip_id == STLINK_CHIPID_STM32_F4_HD) || (sl->chip_id == STLINK_CHIPID_STM32_F411RE) ||
-            (sl->chip_id == STLINK_CHIPID_STM32_F446) || (sl->chip_id == STLINK_CHIPID_STM32_F4_DSI)) {
+            (sl->chip_id == STLINK_CHIPID_STM32_F446) || (sl->chip_id == STLINK_CHIPID_STM32_F4_DSI) || (sl->chip_id == STLINK_CHIPID_STM32_F72XXX)) {
         uint32_t sector=calculate_F4_sectornum(flashaddr);
         if (sector>= 12) {
             sector -= 12;

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -289,9 +289,11 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
         if (retval == -1) {
             return retval;
         }
-    } else if (sl->core_id == STM32F7_CORE_ID ||
-               sl->chip_id == STLINK_CHIPID_STM32_F7 ||
-               sl->chip_id == STLINK_CHIPID_STM32_F7XXXX) {
+    } else if (sl->core_id == STM32F7_CORE_ID            ||
+               sl->chip_id == STLINK_CHIPID_STM32_F7     ||
+               sl->chip_id == STLINK_CHIPID_STM32_F7XXXX ||
+               sl->chip_id == STLINK_CHIPID_STM32_F72XXX
+               ) {
         int retval;
         retval = loader_v_dependent_assignment(sl,
                                                &loader_code, &loader_size,


### PR DESCRIPTION
The F722RE uses the same flash memory map as 512kB flash f4 series. Without these changes the flash would be erased in pages of 2048bytes, rather than the full 16/64/128kb blocks on the hardware.

All the F72x and F73x devices have this same memory layout, so should be fixed by this commit.