### PR TITLE
Reset through AIRCR (#540)

### DIFF
--- a/include/stlink/reg.h
+++ b/include/stlink/reg.h
@@ -12,4 +12,9 @@
 #define STLINK_REG_DCRSR        0xe000edf4
 #define STLINK_REG_DCRDR        0xe000edf8
 
+/* Application Interrupt and Reset Control Register */
+#define STLINK_REG_AIRCR                0xe000ed0c
+#define STLINK_REG_AIRCR_VECTKEY        0x05fa0000
+#define STLINK_REG_AIRCR_SYSRESETREQ    0x00000004
+
 #endif /* STLINK_REG_H_ */

--- a/src/sg.c
+++ b/src/sg.c
@@ -535,6 +535,11 @@ int _stlink_sg_reset(stlink_t *sl) {
     if (stlink_q(sl))
         return -1;
 
+    // Reset through AIRCR so NRST does not need to be connected
+    if (stlink_write_debug32(sl, STLINK_REG_AIRCR,
+                STLINK_REG_AIRCR_VECTKEY | STLINK_REG_AIRCR_SYSRESETREQ))
+        return -1;
+
     stlink_stat(sl, "core reset");
     return 0;
 }

--- a/src/usb.c
+++ b/src/usb.c
@@ -368,10 +368,7 @@ int _stlink_usb_exit_dfu_mode(stlink_t* sl) {
     return 0;
 }
 
-/**
- * TODO - not convinced this does anything...
- * @param sl
- */
+
 int _stlink_usb_reset(stlink_t * sl) {
     struct stlink_libusb * const slu = sl->backend_data;
     unsigned char* const data = sl->q_buf;
@@ -389,7 +386,9 @@ int _stlink_usb_reset(stlink_t * sl) {
         return (int) size;
     }
 
-    return 0;
+    // Reset through AIRCR so NRST does not need to be connected
+    return stlink_write_debug32(sl, STLINK_REG_AIRCR,
+            STLINK_REG_AIRCR_VECTKEY | STLINK_REG_AIRCR_SYSRESETREQ);
 }
 
 


### PR DESCRIPTION
In addition to asserting the NRST line, also request system reset through the
Application Interrupt and Reset Control Register (AIRCR).

This patch has been tested against an STM32L071 using the SWD without connecting the NRST pin.