### PR TITLE
For Issue 726, Semihost SYS_READ returns incorrect value on EOF

### DIFF
--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -307,6 +307,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         int      fd;
         uint32_t buffer_len;
         void    *buffer;
+	int	 read_result;
 
         if (mem_read(sl, r1, args, sizeof (args)) != 0 ) {
             DLOG("Semihosting SYS_READ error: "
@@ -337,7 +338,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         DLOG("Semihosting: read(%d, target_addr:0x%08x, %zu)\n", fd,
              buffer_address, buffer_len);
 
-        *ret = (uint32_t)read(fd, buffer, buffer_len);
+        read_result = (uint32_t)read(fd, buffer, buffer_len);
         saved_errno = errno;
 
         if (*ret == (uint32_t)-1) {
@@ -350,7 +351,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
                 *ret = buffer_len;
                 return -1;
             } else {
-                *ret -= buffer_len;
+                *ret = buffer_len - read_result;
             }
         }
 


### PR DESCRIPTION
Use local variable for read_result instead of *ret, and fix calculation of *ret for EOF case.