### PR TITLE
Further fix for read at EOF, don't write if length is zero.

### DIFF
--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -307,6 +307,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         int      fd;
         uint32_t buffer_len;
         void    *buffer;
+	int	 read_result;
 
         if (mem_read(sl, r1, args, sizeof (args)) != 0 ) {
             DLOG("Semihosting SYS_READ error: "
@@ -337,7 +338,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         DLOG("Semihosting: read(%d, target_addr:0x%08x, %zu)\n", fd,
              buffer_address, buffer_len);
 
-        *ret = (uint32_t)read(fd, buffer, buffer_len);
+        read_result = (uint32_t)read(fd, buffer, buffer_len);
         saved_errno = errno;
 
         if (*ret == (uint32_t)-1) {
@@ -350,7 +351,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
                 *ret = buffer_len;
                 return -1;
             } else {
-                *ret -= buffer_len;
+                *ret = buffer_len - read_result;
             }
         }
 

--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -311,7 +311,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         int      fd;
         uint32_t buffer_len;
         void    *buffer;
-	int	 read_result;
+	ssize_t  read_result;
 
         if (mem_read(sl, r1, args, sizeof (args)) != 0 ) {
             DLOG("Semihosting SYS_READ error: "
@@ -342,10 +342,10 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         DLOG("Semihosting: read(%d, target_addr:0x%08x, %zu)\n", fd,
              buffer_address, buffer_len);
 
-        read_result = (uint32_t)read(fd, buffer, buffer_len);
+        read_result = read(fd, buffer, buffer_len);
         saved_errno = errno;
 
-        if (*ret == (uint32_t)-1) {
+        if (read_result == (uint32_t)-1) {
             *ret = buffer_len;
         } else {
             if (mem_write(sl, buffer_address, buffer, read_result) != 0 ) {

--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -91,6 +91,10 @@ static int mem_read(stlink_t *sl, uint32_t addr, void *data, uint16_t len)
 
 static int mem_write(stlink_t *sl, uint32_t addr, void *data, uint16_t len)
 {
+    // Note: this function can write more than it is asked to!
+    // If addr is not an even 32 bit boundary.
+    if (len == 0) return 0;	// Don't write anything.
+
     int offset = addr % 4;
     int write_len = len + offset;
 
@@ -344,7 +348,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         if (*ret == (uint32_t)-1) {
             *ret = buffer_len;
         } else {
-            if (mem_write(sl, buffer_address, buffer, *ret) != 0 ) {
+            if (mem_write(sl, buffer_address, buffer, read_result) != 0 ) {
                 DLOG("Semihosting SYS_READ error: "
                      "cannot write buffer to target memory\n");
                 free(buffer);


### PR DESCRIPTION
I found a further problem when reading at the end of a file.

If there is some data in the file, but not enough, then after the first read call returns some data, fread will ask for the rest with an updated pointer.  If the first read returned an odd modulo 4 number of bytes, then this second read call will happen with a pointer that is not 32 bit aligned.

In do_semihosting, the second read gets 0 bytes but still calls mem_write.  The code in mem_write which forces an aligned address then writes more data than it should altering the values returned from the first read call.

This change simply has mem_write return without doing anything if the length is zero.