### PR TITLE
Mem write odd

### DIFF
--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -91,6 +91,19 @@ static int mem_read(stlink_t *sl, uint32_t addr, void *data, uint16_t len)
 
 static int mem_write(stlink_t *sl, uint32_t addr, void *data, uint16_t len)
 {
+    // Note: this function can write more than it is asked to!
+    // If addr is not an even 32 bit boundary, or len is not a multiple of 4.
+    //
+    // If only 32 bit values can be written to the target,
+    // then this function should read the target memory at the
+    // start and end of the buffer where it will write more that
+    // the requested bytes. (perhaps reading the whole area is faster??).
+    //
+    // If 16 and 8 bit writes are available, then they could be used instead.
+ 
+    // Just return when the length is zero avoiding unneeded work.
+    if (len == 0) return 0;
+
     int offset = addr % 4;
     int write_len = len + offset;
 

--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -307,6 +307,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         int      fd;
         uint32_t buffer_len;
         void    *buffer;
+	int	 read_result;
 
         if (mem_read(sl, r1, args, sizeof (args)) != 0 ) {
             DLOG("Semihosting SYS_READ error: "
@@ -337,7 +338,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         DLOG("Semihosting: read(%d, target_addr:0x%08x, %zu)\n", fd,
              buffer_address, buffer_len);
 
-        *ret = (uint32_t)read(fd, buffer, buffer_len);
+        read_result = (uint32_t)read(fd, buffer, buffer_len);
         saved_errno = errno;
 
         if (*ret == (uint32_t)-1) {
@@ -350,7 +351,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
                 *ret = buffer_len;
                 return -1;
             } else {
-                *ret -= buffer_len;
+                *ret = buffer_len - read_result;
             }
         }
 

--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -311,7 +311,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         int      fd;
         uint32_t buffer_len;
         void    *buffer;
-	int	 read_result;
+	ssize_t  read_result;
 
         if (mem_read(sl, r1, args, sizeof (args)) != 0 ) {
             DLOG("Semihosting SYS_READ error: "
@@ -342,10 +342,10 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         DLOG("Semihosting: read(%d, target_addr:0x%08x, %zu)\n", fd,
              buffer_address, buffer_len);
 
-        read_result = (uint32_t)read(fd, buffer, buffer_len);
+        read_result = read(fd, buffer, buffer_len);
         saved_errno = errno;
 
-        if (*ret == (uint32_t)-1) {
+        if (read_result == (uint32_t)-1) {
             *ret = buffer_len;
         } else {
             if (mem_write(sl, buffer_address, buffer, read_result) != 0 ) {

--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -91,10 +91,6 @@ static int mem_read(stlink_t *sl, uint32_t addr, void *data, uint16_t len)
 
 static int mem_write(stlink_t *sl, uint32_t addr, void *data, uint16_t len)
 {
-    // Note: this function can write more than it is asked to!
-    // If addr is not an even 32 bit boundary.
-    if (len == 0) return 0;	// Don't write anything.
-
     int offset = addr % 4;
     int write_len = len + offset;
 

--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -351,7 +351,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
                 *ret = buffer_len;
                 return -1;
             } else {
-                *ret = buffer_len - read_result;
+                *ret = buffer_len - (uint32_t)read_result;
             }
         }
 

--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -354,7 +354,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         read_result = read(fd, buffer, buffer_len);
         saved_errno = errno;
 
-        if (read_result == (uint32_t)-1) {
+        if (read_result == -1) {
             *ret = buffer_len;
         } else {
             if (mem_write(sl, buffer_address, buffer, read_result) != 0 ) {

--- a/src/gdbserver/semihosting.c
+++ b/src/gdbserver/semihosting.c
@@ -91,6 +91,10 @@ static int mem_read(stlink_t *sl, uint32_t addr, void *data, uint16_t len)
 
 static int mem_write(stlink_t *sl, uint32_t addr, void *data, uint16_t len)
 {
+    // Note: this function can write more than it is asked to!
+    // If addr is not an even 32 bit boundary.
+    if (len == 0) return 0;	// Don't write anything.
+
     int offset = addr % 4;
     int write_len = len + offset;
 
@@ -344,7 +348,7 @@ int do_semihosting (stlink_t *sl, uint32_t r0, uint32_t r1, uint32_t *ret) {
         if (*ret == (uint32_t)-1) {
             *ret = buffer_len;
         } else {
-            if (mem_write(sl, buffer_address, buffer, *ret) != 0 ) {
+            if (mem_write(sl, buffer_address, buffer, read_result) != 0 ) {
                 DLOG("Semihosting SYS_READ error: "
                      "cannot write buffer to target memory\n");
                 free(buffer);


### PR DESCRIPTION
Here is the first fix to mem_write() again.  This is simply to have it return when len == 0 and that solves my issues with reading at the end of a file when the remaining data is not an even multiple of 4 bytes.

I have also recognized that this function will overwrite target data that is shouldn't if it is ever called with a non-zero length and either the address or length is not a multiple of 4.  I don't know if that situation will ever occur, it does not happen in my limited uses (so far :-) ).  I have added some comments with possible ways to address that issue.