### PR TITLE
FreeBSD define LIBUSB_API_VERSION instead of LIBUSBX_API_VERSION.

### DIFF
--- a/src/sg.c
+++ b/src/sg.c
@@ -963,6 +963,9 @@ static stlink_t* stlink_open(const int verbose) {
         return NULL;
     }
 
+#if defined (__FreeBSD__)
+ #define LIBUSBX_API_VERSION LIBUSB_API_VERSION
+#endif 
 #if LIBUSBX_API_VERSION < 0x01000106
     libusb_set_debug(slsg->libusb_ctx, 3);
 #else


### PR DESCRIPTION
LIBUSB_API_VERSION is not defined on FreeBSD, so it fail to compile.