### PR TITLE
Only do bank calculation on STM32L4 devices with dual banked flash

### DIFF
--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -45,7 +45,7 @@ enum stlink_stm32_chipids {
 	STLINK_CHIPID_STM32_L43X             = 0x435,
 	STLINK_CHIPID_STM32_L496X            = 0x461,
 	STLINK_CHIPID_STM32_L46X             = 0x462,
-	STLINK_CHIPID_STM32_L41X			 = 0x464,
+	STLINK_CHIPID_STM32_L41X             = 0x464,
 	/*
 	* 0x436 is actually assigned to some L1 chips that are called "Medium-Plus"
 	* and some that are called "High".  0x427 is assigned to the other "Medium-

--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -40,10 +40,12 @@ enum stlink_stm32_chipids {
 	* 0x435 covers STM32L43xxx and STM32L44xxx devices
 	* 0x461 covers STM32L496xx and STM32L4A6xx devices
 	* 0x462 covers STM32L45xxx and STM32L46xxx devices
+	* 0x464 covers STM32L41xxx and STM32L42xxx devices
 	*/
 	STLINK_CHIPID_STM32_L43X             = 0x435,
 	STLINK_CHIPID_STM32_L496X            = 0x461,
 	STLINK_CHIPID_STM32_L46X             = 0x462,
+	STLINK_CHIPID_STM32_L41X			 = 0x464,
 	/*
 	* 0x436 is actually assigned to some L1 chips that are called "Medium-Plus"
 	* and some that are called "High".  0x427 is assigned to the other "Medium-


### PR DESCRIPTION
RM0394 covers the STM32L41xx, 42xx, 43xx, 44xx, 45xx, and 46xx. These
devices are all employ single banked flash and have chip id's
of 0x464 for the 41xx/42xx, 0x435 for 43xx/44xx, and 0x462 for 45xx/46xx
It's also worth noting that bit 21 of the FLASH_OPTR register is marked
as resevred for these chips, and isn't an indicator of dual banked
flash.

RM0392 covers the STM32L4x1, cpu_id 0x415 and can be dual banked.

RM0351 covers the STM32L4x5/4x6, cpu_ids 0x415 & 0x461 and can be dual
banked

RM0432 covers the STM32L4Rx/4Sx, cpu_id 0x470 and can be dual banked.

This PR modifies the calculate_L4_page functio to only factor bank
calculations for the devices above which can support dual banked flash.

I also checked the STM32L4 HAL code and it uses the following preprocessor #if statment
```
#if defined (STM32L471xx) || defined (STM32L475xx) || defined (STM32L476xx) || defined (STM32L485xx) || defined (STM32L486xx) || \
    defined (STM32L496xx) || defined (STM32L4A6xx)
```
to identify dual-banked devices,