### PR TITLE
Add support for CS32 micro-controller

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -53,6 +53,7 @@ extern "C" {
     /* cortex core ids */
     // TODO clean this up...
 #define STM32VL_CORE_ID 0x1ba01477
+#define CS32_CORE_ID 0x2ba01477
 #define STM32F7_CORE_ID 0x5ba02477
 
     // Constant STM32 memory map figures

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -262,6 +262,7 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
         loader_code = loader_code_stm32l;
         loader_size = sizeof(loader_code_stm32l);
     } else if (sl->core_id == STM32VL_CORE_ID
+            || sl->core_id == CS32_CORE_ID
             || sl->chip_id == STLINK_CHIPID_STM32_F3
             || sl->chip_id == STLINK_CHIPID_STM32_F3_SMALL
             || sl->chip_id == STLINK_CHIPID_STM32_F303_HIGH


### PR DESCRIPTION
Fixes #756 

I'm pretty sure the name `CS32_CORE_ID` is not appropriate so tell me what I should use.
I have tested and it works, I can upload the STM32duino bootloader on the CS32F103C8T6 board just fine.
