### PR TITLE
Update STM32F3xx chip ID that covers a few different devices.

### DIFF
--- a/src/chipid.c
+++ b/src/chipid.c
@@ -403,10 +403,10 @@ static const struct stlink_chipid_params devices[] = {
             .bootrom_size = 0x1000
         },
         {
-            // STM32F334
-            // RM0364 document was used to find these parameters
+            // STM32F334, STM32F303x6/8, and STM32F328
+            // From RM0364 and RM0316
             .chip_id = STLINK_CHIPID_STM32_F334,
-            .description = "F334 device",
+            .description = "F3xx medium density device", // (RM0316 sec 33.6.1)
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,
             .flash_pagesize = 0x800,


### PR DESCRIPTION
The 'F334' chip ID looks like it also covers a few smaller F3 devices - see RM0316 section 33.6.1, "MCU Device ID Code":

https://www.st.com/resource/en/reference_manual/dm00043574.pdf

I don't know what to write for the description, though; 'F3xx medium density device' probably isn't that great.