### PR TITLE
Fixes issue with versioning stuck at 1.4.0 for version cloned with git. 

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -6,7 +6,7 @@ if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
 	# Working off a git repo, using git versioning
 	# Check if HEAD is pointing to a tag
 	execute_process (
-		COMMAND             "${GIT_EXECUTABLE}" describe --always
+		COMMAND             "${GIT_EXECUTABLE}" describe --always --tag
 		WORKING_DIRECTORY   "${PROJECT_SOURCE_DIR}"
 		OUTPUT_VARIABLE     PROJECT_VERSION
 		OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -20,6 +20,9 @@ if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
 	if (res EQUAL 1)
 		set (PROJECT_VERSION "${PROJECT_VERSION}-dirty")
 	endif()
+
+	# strip a leading v off of the version as proceeding code expectes just the version numbering.
+	string(REGEX REPLACE "^v" "" PROJECT_VERSION ${PROJECT_VERSION})
 
 	string(REGEX REPLACE "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-[.0-9A-Za-z-]+)?([+][.0-9A-Za-z-]+)?$"
 		"\\1;\\2;\\3" PROJECT_VERSION_LIST ${PROJECT_VERSION})


### PR DESCRIPTION
When compiling from source with the repo, the tags of 1.5.0 and v1.5.1 were not annotated (-a flag when generated the tag) and thus did not show up when using the git describe command. Adding the --tag option considers all tag names and allowed versions 1.5.0 and v1.5.1 to be parsed. See https://git-scm.com/docs/git-describe. 

The other change was made to remove the leading v if the tag name contained one. This was done as the code in each utility prints out a leading v already, assuming the version was just a number. Version 1.5.1 was tagged as v1.5.1 necessitating this change.  