### PR TITLE
Fix "unkown chip id", piped output and st-util -v

### DIFF
--- a/src/gdbserver/gdb-server.c
+++ b/src/gdbserver/gdb-server.c
@@ -151,7 +151,7 @@ int parse_options(int argc, char** argv, st_state_t *st) {
                 if (optarg) {
                     st->logging_level = atoi(optarg);
                 } else {
-                    st->logging_level = DEFAULT_LOGGING_LEVEL;
+                    st->logging_level = DEBUG_LOGGING_LEVEL;
                 }
                 break;
             case '1':

--- a/src/logging.c
+++ b/src/logging.c
@@ -22,6 +22,10 @@ int ugly_log(int level, const char *tag, const char *format, ...) {
     if (level > max_level) {
         return 0;
     }
+
+    // Flush to maintain order of streams
+    fflush(stdout);
+
     va_list args;
     va_start(args, format);
     time_t mytt = time(NULL);
@@ -46,6 +50,7 @@ int ugly_log(int level, const char *tag, const char *format, ...) {
         break;
     }
     vfprintf(stderr, format, args);
+    fflush(stderr);
     va_end(args);
     return 1;
 }

--- a/src/usb.c
+++ b/src/usb.c
@@ -923,6 +923,9 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[16
     // Initialize stlink version (sl->version)	
     stlink_version(sl);	
 
+    // Set the stlink clock speed (default is 1800kHz)
+    stlink_set_swdclk(sl, STLINK_SWDCLK_1P8MHZ_DIVISOR);    
+    
     if (reset) {
         if( sl->version.stlink_v > 1 ) stlink_jtag_reset(sl, 2);
         stlink_reset(sl);
@@ -930,9 +933,6 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[16
     }
 
     ret = stlink_load_device_params(sl);
-
-    // Set the stlink clock speed (default is 1800kHz)
-    stlink_set_swdclk(sl, STLINK_SWDCLK_1P8MHZ_DIVISOR);    
 
 on_libusb_error:
     if (ret == -1) {


### PR DESCRIPTION
A few small tweaks.

- I had the problem described in #107, and noticed the official ST-Link Utility's "Hot Plug" mode would work when the SWD freq. was lowered from 4.0 MHz to 1.8 MHz. The utility changes frequency before resetting when using "Connect Under Reset", so I moved it before the reset here as well.
- On Win32 redirecting streams makes them buffered, so without
flushing there would be no output before exit, resulting in #665. BTW using setvbuf to force the streams into line buffered mode doesn't work on Win32.
- Currently st-util's --verbose does nothing, which is quite counterintuitive. The output isn't pretty, but at least it's something.