### PR TITLE
gui: Fix relative path to the UI files needed by stlink-gui-local

### DIFF
--- a/src/tools/gui/CMakeLists.txt
+++ b/src/tools/gui/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(SYSTEM ${gtk_INCLUDE_DIRS})
 
 add_executable(stlink-gui-local ${GUI_SOURCES})
 set_target_properties(stlink-gui-local PROPERTIES
-                      COMPILE_DEFINITIONS STLINK_UI_DIR="${CMAKE_CURRENT_SOURCE_DIR}/gui")
+                      COMPILE_DEFINITIONS STLINK_UI_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(stlink-gui-local ${STLINK_LIB_STATIC} ${gtk_LDFLAGS})
 
 


### PR DESCRIPTION
Fixes #770.

Either of the following work now:

* `mkdir build; pushd build; cmake ..; make -j32 all; ./src/tools/gui/stlink-gui-local; popd`

* `cmake .; make -j32 all; ./src/tools/gui/stlink-gui-local`

This issue most likely has been caused by 4209e4b92416, as `CMAKE_CURRENT_SOURCE_DIR` is interpreted as currently processed source directory and that changed by moving cmake source to different directory.