### PR TITLE
Added call to clear PG bit after Writing to Flash

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -320,7 +320,7 @@ static void set_flash_cr_pg(stlink_t *sl) {
     stlink_write_debug32(sl, cr_reg, x);
 }
 
-static void __attribute__((unused)) clear_flash_cr_pg(stlink_t *sl) {
+static void clear_flash_cr_pg(stlink_t *sl) {
     uint32_t cr_reg, n;
 
     if (sl->flash_type == STLINK_FLASH_TYPE_F4)
@@ -2008,6 +2008,7 @@ int stlink_write_flash(stlink_t *sl, stm32_addr_t addr, uint8_t* base, uint32_t 
         }
 
         /* Relock flash */
+        clear_flash_cr_pg(sl);
         lock_flash(sl);
 
     }	//STM32F4END


### PR DESCRIPTION
The st-flash write utility wasn't clearing the PG bit after it finished writing to Flash.
Luckily you've already implemented the function for clearing the PG bit, so I just added the call right before locking Flash CR again.
The reason this is important is that if I just flashed a firmware, then any subsequent operation will fail, until I clear the PG bit, so I'll have to add code just for that one case. Or a simple power cycle the STM32 clears it.
Anyway it's just a convenience for the flasher utility to clean up after itself :)