### PR TITLE
Add simple read/write support for STM32WB55 chips.

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -77,6 +77,7 @@ extern "C" {
         STLINK_FLASH_TYPE_L4,
         STLINK_FLASH_TYPE_F1_XL,
         STLINK_FLASH_TYPE_G0,
+        STLINK_FLASH_TYPE_WB
     };
 
     struct stlink_reg {

--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -71,7 +71,8 @@ enum stlink_stm32_chipids {
 	STLINK_CHIPID_STM32_F410             = 0x458,
 	STLINK_CHIPID_STM32_F413             = 0x463,
 	STLINK_CHIPID_STM32_L4RX             = 0x470, // taken from the STM32L4R9I-DISCO board
-	STLINK_CHIPID_STM32_G0X1             = 0x460
+	STLINK_CHIPID_STM32_G0X1             = 0x460,
+	STLINK_CHIPID_STM32_WB55             = 0x495
 };
 
 /**

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -519,6 +519,17 @@ static const struct stlink_chipid_params devices[] = {
             .bootrom_size = 0x7800           // 30K (table 2)
         },
         {
+            // STM32WB55 (from RM0434)
+            .chip_id = STLINK_CHIPID_STM32_WB55,
+            .description = "WB55 device",
+            .flash_type = STLINK_FLASH_TYPE_WB,
+            .flash_size_reg = 0x1FFF75E0,
+            .flash_pagesize = 0x1000, // 4K
+            .sram_size = 0x40000,
+            .bootrom_base = 0x1fff0000, // See the memory map
+            .bootrom_size = 0x7000
+        },
+        {
             // unknown
             .chip_id = STLINK_CHIPID_UNKNOWN,
             .description = "unknown device",


### PR DESCRIPTION
This adds support for STM32WB55 chips - I've only tried a simple 'blink' program on the 'Nucleo-68' board, but it seems to work.

The logic and register offsets look about the same as the STM32G0 series, though - I might check if it would be easy to merge that logic, or maybe adapt it to the other chips' abstractions like `set_flash_cr_pg(...)`. Would that be better?