### PR TITLE
Add STLink V3SET VID:PIDs to the udev rules

### DIFF
--- a/etc/udev/rules.d/49-stlinkv3.rules
+++ b/etc/udev/rules.d/49-stlinkv3.rules
@@ -1,0 +1,29 @@
+# STLink V3SET in Dual CDC mode
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3752", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv3_%n"
+
+# STLink V3SET in Dual CDC mode
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3753", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv3_%n"
+    
+# STLink V3SET 
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374d", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv3_%n"
+
+# STLink V3SET 
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374e", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv3_%n"
+    
+# STLink V3SET in normal mode
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374f", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv3_%n"
+    
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.


### PR DESCRIPTION
Added STLink V3 VID:PID to the udev rules. 
Source of the VID:PID list is the openOCD (Antonio who wrote the openOCD patch has some docs from ST, so the list should be valid):
http://openocd.zylin.com/#/c/4717/3/contrib/60-openocd.rules

Adding support for the V3 just the matter of a few adjustments (different endpoints, etc.), what I am planning to implement in texane-stlink soon.