### PR TITLE
Support for "STM32+Audio" v2-1 firmware

### DIFF
--- a/etc/udev/rules.d/49-stlinkv2-1.rules
+++ b/etc/udev/rules.d/49-stlinkv2-1.rules
@@ -2,6 +2,10 @@
 # ie, STM32F0, STM32F4.
 # STM32VL has st/linkv1, which is quite different
 
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374a", \
+    MODE:="0666", \
+    SYMLINK+="stlinkv2-1_%n"
+
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", \
     MODE:="0666", \
     SYMLINK+="stlinkv2-1_%n"

--- a/include/stlink/usb.h
+++ b/include/stlink/usb.h
@@ -18,10 +18,11 @@
 extern "C" {
 #endif
 
-#define STLINK_USB_VID_ST            0x0483
-#define STLINK_USB_PID_STLINK        0x3744
-#define STLINK_USB_PID_STLINK_32L    0x3748
-#define STLINK_USB_PID_STLINK_NUCLEO 0x374b
+#define STLINK_USB_VID_ST               0x0483
+#define STLINK_USB_PID_STLINK           0x3744
+#define STLINK_USB_PID_STLINK_32L       0x3748
+#define STLINK_USB_PID_STLINK_32L_AUDIO 0x374a
+#define STLINK_USB_PID_STLINK_NUCLEO    0x374b
 
 #define STLINK_SG_SIZE 31
 #define STLINK_CMD_SIZE 16

--- a/src/usb.c
+++ b/src/usb.c
@@ -827,7 +827,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[16
             }
         }
 
-        if ((desc.idProduct == STLINK_USB_PID_STLINK_32L) || (desc.idProduct == STLINK_USB_PID_STLINK_NUCLEO)) {
+        if ((desc.idProduct == STLINK_USB_PID_STLINK_32L) || (desc.idProduct == STLINK_USB_PID_STLINK_NUCLEO) || (desc.idProduct == STLINK_USB_PID_STLINK_32L_AUDIO)) {
             struct libusb_device_handle *handle;
 
             ret = libusb_open(list[cnt], &handle);
@@ -901,7 +901,7 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[16
 
     // TODO - could use the scanning techniq from stm8 code here...
     slu->ep_rep = 1 /* ep rep */ | LIBUSB_ENDPOINT_IN;
-    if (desc.idProduct == STLINK_USB_PID_STLINK_NUCLEO) {
+    if (desc.idProduct == STLINK_USB_PID_STLINK_NUCLEO || desc.idProduct == STLINK_USB_PID_STLINK_32L_AUDIO) {
         slu->ep_req = 1 /* ep req */ | LIBUSB_ENDPOINT_OUT;
     } else {
         slu->ep_req = 2 /* ep req */ | LIBUSB_ENDPOINT_OUT;
@@ -973,6 +973,7 @@ static size_t stlink_probe_usb_devs(libusb_device **devs, stlink_t **sldevs[]) {
         }
 
         if (desc.idProduct != STLINK_USB_PID_STLINK_32L &&
+            desc.idProduct != STLINK_USB_PID_STLINK_32L_AUDIO && 
             desc.idProduct != STLINK_USB_PID_STLINK_NUCLEO)
             continue;
 
@@ -996,7 +997,8 @@ static size_t stlink_probe_usb_devs(libusb_device **devs, stlink_t **sldevs[]) {
             break;
         }
 
-        if (desc.idProduct != STLINK_USB_PID_STLINK_32L &&
+        if (desc.idProduct != STLINK_USB_PID_STLINK_32L && 
+            desc.idProduct != STLINK_USB_PID_STLINK_32L_AUDIO && 
             desc.idProduct != STLINK_USB_PID_STLINK_NUCLEO)
             continue;
 


### PR DESCRIPTION
Why? 
Flashing "STM32+Audio" is only way for have St-link v2-1 with UART on stm32f103c8. 
Other firmwares can't be flashed with ST Utils ("firmware is too big"). 

```
$ lsusb
...
Bus 002 Device 098: ID 0483:374a STMicroelectronics
...
```

Brefore patch:
```
$ sudo st-info --probe
Found 0 stlink programmers
```

After patch:
```
$ sudo st-info --probe
Found 1 stlink programmers
 serial: ...deleted...
openocd: "...deleted..."
  flash: 65536 (pagesize: 1024)
   sram: 20480
 chipid: 0x0410
  descr: F1 Medium-density device
```
