### PR TITLE
Add support for CS32F103C8T6

### DIFF
--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -262,6 +262,7 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
         loader_code = loader_code_stm32l;
         loader_size = sizeof(loader_code_stm32l);
     } else if (sl->core_id == STM32VL_CORE_ID
+            || sl->chip_id == STLINK_CHIPID_STM32_F1_MEDIUM
             || sl->chip_id == STLINK_CHIPID_STM32_F3
             || sl->chip_id == STLINK_CHIPID_STM32_F3_SMALL
             || sl->chip_id == STLINK_CHIPID_STM32_F303_HIGH


### PR DESCRIPTION
CS32F103C8T6 is clone of STM32F103C8T6 but with incorrect core_id number. ( #757 )

All original STM32F1xx has core id STM32VL_CORE_ID, but CS32F103 has different core id 0x2BA01477 (as original STM32F3xx, STM32F4xx and STM32L1xx).

This commit should not affect other devices because all original STM32F1xx (include STLINK_CHIPID_STM32_F1_MEDIUM) has core id STM32VL_CORE_ID.