### PR TITLE
Allow for 64 Bytes serials (with new Nucleo-L476RG)

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -66,6 +66,8 @@ extern "C" {
 #define STLINK_SWDCLK_15KHZ_DIVISOR		265
 #define STLINK_SWDCLK_5KHZ_DIVISOR		798
 
+#define STLINK_SERIAL_MAX_SIZE 64
+
     /* Enough space to hold both a V2 command or a V1 command packaged as generic scsi*/
 #define C_BUF_LEN 32
 
@@ -144,7 +146,7 @@ typedef struct flash_loader {
         uint32_t chip_id;
         int core_stat;
 
-        char serial[16];
+        char serial[STLINK_SERIAL_MAX_SIZE];
         int serial_size;
 
         enum stlink_flash_type flash_type;

--- a/include/stlink/tools/flash.h
+++ b/include/stlink/tools/flash.h
@@ -13,7 +13,7 @@ struct flash_opts
 {
     enum flash_cmd cmd;
     const char* devname;
-    uint8_t serial[16];
+    uint8_t serial[STLINK_SERIAL_MAX_SIZE];
     const char* filename;
     stm32_addr_t addr;
     size_t size;

--- a/include/stlink/usb.h
+++ b/include/stlink/usb.h
@@ -45,7 +45,7 @@ extern "C" {
      * @retval NULL   Error while opening the stlink
      * @retval !NULL  Stlink found and ready to use
      */
-    stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[16]);
+    stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[STLINK_SERIAL_MAX_SIZE]);
     size_t stlink_probe_usb(stlink_t **stdevs[]);
     void stlink_probe_usb_free(stlink_t **stdevs[], size_t size);
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -767,7 +767,7 @@ static stlink_backend_t _stlink_usb_backend = {
     _stlink_usb_set_swdclk
 };
 
-stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[16])
+stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[STLINK_SERIAL_MAX_SIZE])
 {
     stlink_t* sl = NULL;
     struct stlink_libusb* slu = NULL;
@@ -1003,7 +1003,7 @@ static size_t stlink_probe_usb_devs(libusb_device **devs, stlink_t **sldevs[]) {
             continue;
 
         struct libusb_device_handle* handle;
-        char serial[16];
+        char serial[STLINK_SERIAL_MAX_SIZE];
         memset(serial, 0, sizeof(serial));
 
         ret = libusb_open(dev, &handle);


### PR DESCRIPTION
On Nucleo boards the serial gets truncated. This allows for longer serials.