### PR TITLE
Do not issue JTAG reset on stlink-v1

### DIFF
--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -92,9 +92,11 @@ int main(int ac, char** av)
     }
 
     if (o.reset){
-        if (stlink_jtag_reset(sl, 2)) {
-            printf("Failed to reset JTAG\n");
-            goto on_error;
+        if (sl->version.stlink_v > 1) {
+            if (stlink_jtag_reset(sl, 2)) {
+                printf("Failed to reset JTAG\n");
+                goto on_error;
+            }
         }
 
         if (stlink_reset(sl)) {
@@ -185,9 +187,11 @@ int main(int ac, char** av)
         }
     } else if (o.cmd == CMD_RESET)
     {
-        if (stlink_jtag_reset(sl, 2)) {
-            printf("Failed to reset JTAG\n");
-            goto on_error;
+        if (sl->version.stlink_v > 1) {
+            if (stlink_jtag_reset(sl, 2)) {
+                printf("Failed to reset JTAG\n");
+                goto on_error;
+            }
         }
 
         if (stlink_reset(sl)) {
@@ -212,7 +216,7 @@ int main(int ac, char** av)
     }
 
     if (o.reset){
-        stlink_jtag_reset(sl,2);
+        if (sl->version.stlink_v > 1) stlink_jtag_reset(sl, 2);
         stlink_reset(sl);
     }
 


### PR DESCRIPTION
Using  stlink_jtag_reset with stlink-v1 fails with:
[!] send_recv read reply failed: LIBUSB_ERROR_PIPE
[!] send_recv STLINK_JTAG_DRIVE_NRST
Failed to reset JTAG
[!] send_recv send request failed: LIBUSB_ERROR_PIPE
[!] send_recv STLINK_JTAG_WRITEDEBUG_32BIT

This patch complete https://github.com/texane/stlink/pull/481 to fix all calls to this function with stlink-v1