### PR TITLE
Fix flash size of stm32discovery vl

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -800,7 +800,7 @@ int stlink_load_device_params(stlink_t *sl) {
         flash_size = flash_size >>16;
     flash_size = flash_size & 0xffff;
 
-    if ((sl->chip_id == STLINK_CHIPID_STM32_L1_MEDIUM || sl->chip_id == STLINK_CHIPID_STM32_L1_MEDIUM_PLUS) && ( flash_size == 0 )) {
+    if ((sl->chip_id == STLINK_CHIPID_STM32_L1_MEDIUM || sl->chip_id == STLINK_CHIPID_STM32_F1_VL_MEDIUM_LOW || sl->chip_id == STLINK_CHIPID_STM32_L1_MEDIUM_PLUS) && ( flash_size == 0 )) {
         sl->flash_size = 128 * 1024;
     } else if (sl->chip_id == STLINK_CHIPID_STM32_L1_CAT2) {
         sl->flash_size = (flash_size & 0xff) * 1024;


### PR DESCRIPTION
stlink seems to be unable to read flash size on stm32discovery F1 VL (stlink-v1):
st-flash 1.5.1-32-g4909dd8
2019-09-02T17:49:05 INFO common.c: Loading device parameters....
2019-09-02T17:49:05 INFO common.c: Device connected is: F1 Medium/Low-density Value Line device, id 0x10016420
2019-09-02T17:49:05 INFO common.c: SRAM size: 0x1000 bytes (4 KiB), Flash: 0 bytes (0 KiB) in pages of 1024 bytes

Since the flash size is equal to zero stm32F1 cannot be flashed with :
Unknown memory region

This patch add a work around like for L1 to fix manually size if value read equal 0.