### PR TITLE
added support for writing option bytes on STM32L0

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ then it would be written to the memory.
 
 ## Writing Option Bytes
 
-Example to read and write option bytes (currently writing only supported for STM32G0)
+Example to read and write option bytes (currently writing only supported for STM32G0 and STM32L0)
 ```
 ./st-flash --debug --reset --format binary --flash=128k read option_bytes_dump.bin 0x1FFF7800 4
 ./st-flash --debug --reset --format binary --flash=128k write option_bytes_dump.bin 0x1FFF7800

--- a/include/stm32.h
+++ b/include/stm32.h
@@ -15,5 +15,6 @@
 #define STM32_FLASH_BASE           ((uint32_t)0x08000000)
 #define STM32_SRAM_BASE            ((uint32_t)0x20000000)
 #define STM32_G0_OPTION_BYTES_BASE ((uint32_t)0x1FFF7800)
+#define STM32_L0_CAT2_OPTION_BYTES_BASE ((uint32_t)0x1FF80000)
 
 #endif /* STM32_H */

--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -164,7 +164,7 @@ int main(int ac, char** av)
                 goto on_error;
             }
         }
-        else if (o.addr == STM32_G0_OPTION_BYTES_BASE) {
+        else if (o.addr == STM32_G0_OPTION_BYTES_BASE || o.addr == STM32_L0_CAT2_OPTION_BYTES_BASE) {
             err = stlink_fwrite_option_bytes(sl, o.filename, o.addr);
             if (err == -1)
             {


### PR DESCRIPTION
We use it in production to do a mass erase for removing the LEVEL_1 access protection flag