### PR TITLE
added CSK32F103C8T6 a stm32f103c8t6 clone with coreid 0x2ba01477

### DIFF
--- a/include/stm32.h
+++ b/include/stm32.h
@@ -9,6 +9,7 @@
 
 // cortex core ids
 #define STM32VL_CORE_ID 0x1ba01477
+#define CS32VL_CORE_ID 0x2ba01477
 #define STM32F7_CORE_ID 0x5ba02477
 
 // Constant STM32 memory map figures

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -262,6 +262,7 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
         loader_code = loader_code_stm32l;
         loader_size = sizeof(loader_code_stm32l);
     } else if (sl->core_id == STM32VL_CORE_ID
+            || sl->chip_id == CS32VL_CORE_ID
             || sl->chip_id == STLINK_CHIPID_STM32_F1_MEDIUM
             || sl->chip_id == STLINK_CHIPID_STM32_F3
             || sl->chip_id == STLINK_CHIPID_STM32_F3_SMALL


### PR DESCRIPTION
Here's the pull request we talked about a few minutes ago.
This adds support to CSK32F103C8T6 a stm32f103c8t6 clone with an unsupported coreid