### PR TITLE
Added Read/Write command for Option-Bytes on STM32F2 series 

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -222,6 +222,7 @@ typedef struct flash_loader {
     int write_loader_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* size);
     int stlink_fread(stlink_t* sl, const char* path, bool is_ihex, stm32_addr_t addr, size_t size);
     int stlink_load_device_params(stlink_t *sl);
+    int stlink_read_option_bytes_f2(stlink_t *sl, uint32_t* option_byte);
 
 #include "stlink/sg.h"
 #include "stlink/usb.h"

--- a/include/stlink.h
+++ b/include/stlink.h
@@ -200,6 +200,7 @@ typedef struct flash_loader {
     int stlink_mwrite_flash(stlink_t *sl, uint8_t* data, uint32_t length, stm32_addr_t addr);
     int stlink_fwrite_flash(stlink_t *sl, const char* path, stm32_addr_t addr);
     int stlink_fwrite_option_bytes(stlink_t *sl, const char* path, stm32_addr_t addr);
+    int stlink_fwrite_option_bytes_32bit(stlink_t *sl,uint32_t val);
     int stlink_mwrite_sram(stlink_t *sl, uint8_t* data, uint32_t length, stm32_addr_t addr);
     int stlink_fwrite_sram(stlink_t *sl, const char* path, stm32_addr_t addr);
     int stlink_verify_write_flash(stlink_t *sl, stm32_addr_t address, uint8_t *data, uint32_t length);

--- a/include/stlink/tools/flash.h
+++ b/include/stlink/tools/flash.h
@@ -9,6 +9,7 @@
 
 enum flash_cmd {FLASH_CMD_NONE = 0, FLASH_CMD_WRITE = 1, FLASH_CMD_READ = 2, FLASH_CMD_ERASE = 3, CMD_RESET = 4};
 enum flash_format {FLASH_FORMAT_BINARY = 0, FLASH_FORMAT_IHEX = 1};
+enum flash_area {FLASH_MAIN_MEMORY = 0, FLASH_SYSTEM_MEMORY = 1,FLASH_OTP = 2, FLASH_OPTION_BYTES = 3};
 struct flash_opts
 {
     enum flash_cmd cmd;
@@ -20,10 +21,12 @@ struct flash_opts
     int reset;
     int log_level;
     enum flash_format format;
+    enum flash_area area;
+    uint32_t val;
     size_t flash_size;	/* --flash=n[k][m] */
 };
 
-#define FLASH_OPTS_INITIALIZER {0, NULL, { 0 }, NULL, 0, 0, 0, 0, 0, 0 }
+#define FLASH_OPTS_INITIALIZER {0, NULL, { 0 }, NULL, 0, 0, 0, 0, 0, 0, 0, 0 }
 
 int flash_get_opts(struct flash_opts* o, int ac, char** av);
 

--- a/include/stm32.h
+++ b/include/stm32.h
@@ -16,5 +16,5 @@
 #define STM32_SRAM_BASE            ((uint32_t)0x20000000)
 #define STM32_G0_OPTION_BYTES_BASE ((uint32_t)0x1FFF7800)
 #define STM32_L0_CAT2_OPTION_BYTES_BASE ((uint32_t)0x1FF80000)
-
+#define STM32_F2_OPTION_BYTES_BASE ((uint32_t)0x1FFFC000)
 #endif /* STM32_H */

--- a/src/tools/flash.c
+++ b/src/tools/flash.c
@@ -38,6 +38,7 @@ static void usage(void)
     puts("                       fsize: Use decimal, octal or hex by prefix 0xXXX for hex, optionally followed by k=KB, or m=MB (eg. --flash=128k)");
     puts("                       Format may be 'binary' (default) or 'ihex', although <addr> must be specified for binary format only.");
     puts("                       ./st-flash [--version]");
+    puts("example write option byte: ./st-flash --debug --reset --area=option write 0xXXXXXXXX");
 }
 
 int main(int ac, char** av)
@@ -131,7 +132,6 @@ int main(int ac, char** av)
     if (o.cmd == FLASH_CMD_WRITE) /* write */
     {
         size_t size = 0;
-
         if(o.format == FLASH_FORMAT_IHEX) {
             err = stlink_parse_ihex(o.filename, stlink_get_erased_pattern(sl), &mem, &size, &o.addr);
             if (err == -1) {
@@ -139,7 +139,6 @@ int main(int ac, char** av)
                 goto on_error;
             }
         }
-
         if ((o.addr >= sl->flash_base) &&
                 (o.addr < sl->flash_base + sl->flash_size)) {
             if(o.format == FLASH_FORMAT_IHEX)
@@ -164,8 +163,16 @@ int main(int ac, char** av)
                 goto on_error;
             }
         }
-        else if (o.addr == STM32_G0_OPTION_BYTES_BASE || o.addr == STM32_L0_CAT2_OPTION_BYTES_BASE) {
+        else if (o.addr == STM32_G0_OPTION_BYTES_BASE || o.addr == STM32_L0_CAT2_OPTION_BYTES_BASE){
             err = stlink_fwrite_option_bytes(sl, o.filename, o.addr);
+            if (err == -1)
+            {
+                printf("stlink_fwrite_option_bytes() == -1\n");
+                goto on_error;
+            }
+        }
+        else if (o.area == FLASH_OPTION_BYTES){
+            err = stlink_fwrite_option_bytes_32bit(sl, o.val);
             if (err == -1)
             {
                 printf("stlink_fwrite_option_bytes() == -1\n");

--- a/src/tools/flash_opts.c
+++ b/src/tools/flash_opts.c
@@ -172,6 +172,7 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av)
             break;
 
         case FLASH_CMD_READ:     // expect filename, addr and size
+            if((o->area == FLASH_OPTION_BYTES) &&(ac == 0)) break;
             if (ac != 3) return -1;
 
             o->filename = av[0];

--- a/src/tools/flash_opts.c
+++ b/src/tools/flash_opts.c
@@ -58,6 +58,29 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av)
 
             serial_specified = true;
         }
+        else if (strcmp(av[0], "--area") == 0 || starts_with(av[0], "--area=")) {
+            const char * area;
+            if(strcmp(av[0], "--area") == 0) {
+                ac--;
+                av++;
+                if (ac < 1) return -1;
+                area = av[0];
+            }
+            else {
+                area = av[0] + strlen("--area=");
+            }
+            if (strcmp(area, "main") == 0)
+                o->area = FLASH_MAIN_MEMORY;
+            else if (strcmp(area, "system") == 0)
+                o->area = FLASH_SYSTEM_MEMORY;
+            else if (strcmp(area, "otp") == 0)
+                o->area = FLASH_OTP;
+            else if (strcmp(area, "option") == 0)
+                o->area = FLASH_OPTION_BYTES;
+            else
+                return -1;
+
+        }
         else if (strcmp(av[0], "--format") == 0 || starts_with(av[0], "--format=")) {
             const char * format;
             if(strcmp(av[0], "--format") == 0) {
@@ -161,7 +184,12 @@ int flash_get_opts(struct flash_opts* o, int ac, char** av)
             break;
 
         case FLASH_CMD_WRITE:
-            if(o->format == FLASH_FORMAT_BINARY) {    // expect filename and addr
+            if(o->area == FLASH_OPTION_BYTES){
+                if(ac != 1) return -1;
+
+                o->val = (uint32_t)strtoul(av[0], &tail, 16);
+            }
+            else if(o->format == FLASH_FORMAT_BINARY) {    // expect filename and addr
                 if (ac != 2) return -1;
 
                 o->filename = av[0];


### PR DESCRIPTION
Option Bytes were not accessible for STM32F2 devices, so I added read/write command for Option Bytes on STM32F2 devices.

## example command
### read operation  
 st-flash --reset --area=option read > option_byte 
### write operation  
 st-flash --reset --area=option write 0x0FFFAAE0
