### PR TITLE
[doc/trivial] Fix st-flash manpage read example

### DIFF
--- a/doc/man/st-flash.1
+++ b/doc/man/st-flash.1
@@ -65,7 +65,7 @@ Read firmware from device (4096 bytes)
 .IP
 .nf
 \f[C]
-$ st\-flash read firmware.bin 0x8000000 4096
+$ st\-flash read firmware.bin 0x8000000 0x1000
 \f[R]
 .fi
 .PP

--- a/doc/man/st-flash.md
+++ b/doc/man/st-flash.md
@@ -61,7 +61,7 @@ Flash `firmware.bin` to device
 
 Read firmware from device (4096 bytes)
 
-    $ st-flash read firmware.bin 0x8000000 4096
+    $ st-flash read firmware.bin 0x8000000 0x1000
 
 Erase firmware from device
 


### PR DESCRIPTION
SIZE must be specified as hexdecimal number (as per both documentation and implementation), current manpage example unexpectedly reads 0x4096 (16534) bytes instead of 4096 (0x1000).
(actually, 0x prefix is not necessary, number interpreted as hexdecimal anyway, and maybe confusing readers into thinking that number will be interpreted as decimal [without prefix] or octal [with 0 prefix])