### PR TITLE
clear the PG bit before setting the PER bit

### DIFF
--- a/include/stm32.h
+++ b/include/stm32.h
@@ -9,7 +9,6 @@
 
 // cortex core ids
 #define STM32VL_CORE_ID 0x1ba01477
-#define CS32VL_CORE_ID 0x2ba01477
 #define STM32F7_CORE_ID 0x5ba02477
 
 // Constant STM32 memory map figures

--- a/src/common.c
+++ b/src/common.c
@@ -1893,6 +1893,9 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
         /* unlock if locked */
         unlock_flash_if(sl);
 
+        /* clear the pg bit */
+        clear_flash_cr_pg(sl);
+        
         /* set the page erase bit */
         set_flash_cr_per(sl);
 

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -267,7 +267,6 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
         loader_code = loader_code_stm32l;
         loader_size = sizeof(loader_code_stm32l);
     } else if (sl->core_id == STM32VL_CORE_ID ||
-               sl->core_id == CS32VL_CORE_ID ||
                sl->chip_id == STLINK_CHIPID_STM32_F1_MEDIUM ||
                sl->chip_id == STLINK_CHIPID_STM32_F3 ||
                sl->chip_id == STLINK_CHIPID_STM32_F3_SMALL ||


### PR DESCRIPTION
after the flash loader ran the PG bit is still set in the CR register.
in order to program the next page that page needs to be erased first and to get that working the PG bit has to be cleared so the flash controller knows what to do.
this fixes #579