### PR TITLE
fix for signed/unsigned comparison

### DIFF
--- a/include/stm32.h
+++ b/include/stm32.h
@@ -9,7 +9,6 @@
 
 // cortex core ids
 #define STM32VL_CORE_ID 0x1ba01477
-#define CS32VL_CORE_ID 0x2ba01477
 #define STM32F7_CORE_ID 0x5ba02477
 
 // Constant STM32 memory map figures

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -267,7 +267,6 @@ int stlink_flash_loader_write_to_sram(stlink_t *sl, stm32_addr_t* addr, size_t* 
         loader_code = loader_code_stm32l;
         loader_size = sizeof(loader_code_stm32l);
     } else if (sl->core_id == STM32VL_CORE_ID ||
-               sl->core_id == CS32VL_CORE_ID ||
                sl->chip_id == STLINK_CHIPID_STM32_F1_MEDIUM ||
                sl->chip_id == STLINK_CHIPID_STM32_F3 ||
                sl->chip_id == STLINK_CHIPID_STM32_F3_SMALL ||

--- a/src/usb.c
+++ b/src/usb.c
@@ -189,7 +189,7 @@ int _stlink_usb_version(stlink_t *sl) {
         cmd[i++] = STLINK_APIV3_GET_VERSION_EX;
 
         size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
-        if (size != rep_len) {
+        if (size == -1 || (uint32_t)(size) != rep_len) {
             printf("[!] send_recv STLINK_APIV3_GET_VERSION_EX\n");
             return (int) size;
         }


### PR DESCRIPTION
compilation error with gcc-8:

```
/home/pi/stlink/src/usb.c: In function '_stlink_usb_version':
/home/pi/stlink/src/usb.c:192:18: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
         if (size != rep_len) {
                  ^~
cc1: all warnings being treated as errors
```