### PR TITLE
Fixed wait-loop for flash_loader_run() & F72/F73 device description

### DIFF
--- a/src/chipid.c
+++ b/src/chipid.c
@@ -27,7 +27,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             //RM0431 and DS document was used to find these paramaters
             .chip_id = STLINK_CHIPID_STM32_F72XXX,
-            .description = "F72 device",
+            .description = "F72/F73 device",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1ff07a22,      // section 35.2
             .flash_pagesize = 0x800,           // No flash pages

--- a/src/flash_loader.c
+++ b/src/flash_loader.c
@@ -384,10 +384,20 @@ int stlink_flash_loader_run(stlink_t *sl, flash_loader_t* fl, stm32_addr_t targe
     /* run loader */
     stlink_run(sl);
 
-#define WAIT_ROUNDS 10000
+// This piece of code used to try to spin for .1 second by waiting 
+// doing 10000 rounds of 10 microseconds. But because this usually runs
+// on Unix-like OSes, the 10 microseconds get rounded up to the "tick" 
+// (actually almost two ticks) of the system. 1 milisecond. Thus, the
+// ten thousand attempts, when "something goes wrong" that requires 
+// the error message "flash loader run error" would wait for something 
+// like 20 seconds before coming up with the error. 
+// by increasing the sleep-per-round to the same order-of-magnitude as 
+// the tick-rounding that the OS uses, the wait until the error message is
+// reduced to the same order of magnitude as what was intended. -- REW. 
+#define WAIT_ROUNDS 100
     /* wait until done (reaches breakpoint) */
     for (i = 0; i < WAIT_ROUNDS; i++) {
-        usleep(10);
+        usleep(1000);
         if (stlink_is_core_halted(sl))
             break;
     }


### PR DESCRIPTION
It seems my code also has the F72 fix. Do you really need that in a separate pull request?

Looking at that: Shouldn't it be "F72x / F73x device"? Wouldn't that be clearer? All devices have a 3-digit type number. I noticed that I often use the F072, but thats a different beast than the F72x and F730.... 