### PR TITLE
Silence unnecessary messages (Fixes #240)

### DIFF
--- a/src/chipid.c
+++ b/src/chipid.c
@@ -5,7 +5,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             //RM0410 document was used to find these paramaters
             .chip_id = STLINK_CHIPID_STM32_F7XXXX,
-            .description = "F76xxx device",
+            .description = "F76xxx",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1ff0f442,      // section 45.2
             .flash_pagesize = 0x800,           // No flash pages
@@ -16,7 +16,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             //RM0385 and DS10916 document was used to find these paramaters
             .chip_id = STLINK_CHIPID_STM32_F7,
-            .description = "F7 device",
+            .description = "F7xx",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1ff0f442,      // section 41.2
             .flash_pagesize = 0x800,           // No flash pages
@@ -27,7 +27,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             //RM0431 and DS document was used to find these paramaters
             .chip_id = STLINK_CHIPID_STM32_F72XXX,
-            .description = "F72/F73 device",
+            .description = "F72x/F73x",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1ff07a22,      // section 35.2
             .flash_pagesize = 0x800,           // No flash pages
@@ -37,7 +37,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         { // table 2, PM0063
             .chip_id = STLINK_CHIPID_STM32_F1_MEDIUM,
-            .description = "F1 Medium-density device",
+            .description = "F1xx Medium-density",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7e0,
             .flash_pagesize = 0x400,
@@ -47,7 +47,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {  // table 1, PM0059
             .chip_id = STLINK_CHIPID_STM32_F2,
-            .description = "F2 device",
+            .description = "F2xx",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1fff7a22, /* As in RM0033 Rev 5*/
             .flash_pagesize = 0x20000,
@@ -67,7 +67,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F4,
-            .description = "F4 device",
+            .description = "F4xx",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1FFF7A22,  /* As in rm0090 since Rev 2*/
             .flash_pagesize = 0x4000,
@@ -77,7 +77,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F4_DSI,
-            .description = "F46x and F47x device",
+            .description = "F46x/F47x",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1FFF7A22,  /* As in rm0090 since Rev 2*/
             .flash_pagesize = 0x4000,
@@ -87,7 +87,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F4_HD,
-            .description = "F42x and F43x device",
+            .description = "F42x/F43x",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1FFF7A22,  /* As in rm0090 since Rev 2*/
             .flash_pagesize = 0x4000,
@@ -97,7 +97,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F4_LP,
-            .description = "F4 device (low power)",
+            .description = "F4xx (low power)",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1FFF7A22,
             .flash_pagesize = 0x4000,
@@ -107,7 +107,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F411RE,
-            .description = "F4 device (low power) - stm32f411re",
+            .description = "stm32f411re",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1FFF7A22,
             .flash_pagesize = 0x4000,
@@ -117,7 +117,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F4_DE,
-            .description = "F4 device (Dynamic Efficency)",
+            .description = "F4xx (Dynamic Efficency)",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1FFF7A22,
             .flash_pagesize = 0x4000,
@@ -127,7 +127,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F1_HIGH,
-            .description = "F1 High-density device",
+            .description = "F1xx High-density",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7e0,
             .flash_pagesize = 0x800,
@@ -139,7 +139,7 @@ static const struct stlink_chipid_params devices[] = {
             // This ignores the EEPROM! (and uses the page erase size,
             // not the sector write protection...)
             .chip_id = STLINK_CHIPID_STM32_L1_MEDIUM,
-            .description = "L1 Med-density device",
+            .description = "L1xx Medium-density",
             .flash_type = STLINK_FLASH_TYPE_L0,
             .flash_size_reg = 0x1ff8004c,
             .flash_pagesize = 0x100,
@@ -149,7 +149,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_L1_CAT2,
-            .description = "L1 Cat.2 device",
+            .description = "L1xx Cat.2",
             .flash_type = STLINK_FLASH_TYPE_L0,
             .flash_size_reg = 0x1ff8004c,
             .flash_pagesize = 0x100,
@@ -159,7 +159,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_L1_MEDIUM_PLUS,
-            .description = "L1 Medium-Plus-density device",
+            .description = "L1xx Medium-Plus-density",
             .flash_type = STLINK_FLASH_TYPE_L0,
             .flash_size_reg = 0x1ff800cc,
             .flash_pagesize = 0x100,
@@ -169,7 +169,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_L1_HIGH,
-            .description = "L1 High-density device",
+            .description = "L1xx High-density",
             .flash_type = STLINK_FLASH_TYPE_L0,
             .flash_size_reg = 0x1ff800cc,
             .flash_pagesize = 0x100,
@@ -189,7 +189,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F1_CONN,
-            .description = "F1 Connectivity line device",
+            .description = "F1 Connectivity line",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7e0,
             .flash_pagesize = 0x800,
@@ -199,7 +199,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {//Low and Medium density VL have same chipid. RM0041 25.6.1
             .chip_id = STLINK_CHIPID_STM32_F1_VL_MEDIUM_LOW,
-            .description = "F1 Medium/Low-density Value Line device",
+            .description = "F1xx Value Line",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7e0,
             .flash_pagesize = 0x400,
@@ -210,7 +210,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             // STM32F446x family. Support based on DM00135183.pdf (RM0390) document.
             .chip_id = STLINK_CHIPID_STM32_F446,
-            .description = "F446 device",
+            .description = "F446",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1fff7a22,
             .flash_pagesize = 0x20000,
@@ -221,7 +221,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             // STM32F410 MCUs. Support based on DM00180366.pdf (RM0401) document.
             .chip_id = STLINK_CHIPID_STM32_F410,
-            .description = "F410 device",
+            .description = "F410",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1fff7a22,
             .flash_pagesize = 0x4000,
@@ -233,7 +233,7 @@ static const struct stlink_chipid_params devices[] = {
             // This is STK32F303VCT6 device from STM32 F3 Discovery board.
             // Support based on DM00043574.pdf (RM0316) document.
             .chip_id = STLINK_CHIPID_STM32_F3,
-            .description = "F3 device",
+            .description = "F3xx",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,
             .flash_pagesize = 0x800,
@@ -245,7 +245,7 @@ static const struct stlink_chipid_params devices[] = {
             // This is STK32F373VCT6 device from STM32 F373 eval board
             // Support based on 303 above (37x and 30x have same memory map)
             .chip_id = STLINK_CHIPID_STM32_F37x,
-            .description = "F3 device",
+            .description = "F3xx",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,
             .flash_pagesize = 0x800,
@@ -255,7 +255,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F1_VL_HIGH,
-            .description = "F1 High-density value line device",
+            .description = "F1xx High-density value line",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7e0,
             .flash_pagesize = 0x800,
@@ -265,7 +265,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F1_XL,
-            .description = "F1 XL-density device",
+            .description = "F1xx XL-density",
             .flash_type = STLINK_FLASH_TYPE_F1_XL,
             .flash_size_reg = 0x1ffff7e0,
             .flash_pagesize = 0x800,
@@ -277,7 +277,7 @@ static const struct stlink_chipid_params devices[] = {
             //Use this as an example for mapping future chips:
             //RM0091 document was used to find these paramaters
             .chip_id = STLINK_CHIPID_STM32_F0_CAN,
-            .description = "F07x device",
+            .description = "F07x",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,      // "Flash size data register" (pg735)
             .flash_pagesize = 0x800,           // Page sizes listed in Table 4
@@ -289,7 +289,7 @@ static const struct stlink_chipid_params devices[] = {
             //Use this as an example for mapping future chips:
             //RM0091 document was used to find these paramaters
             .chip_id = STLINK_CHIPID_STM32_F0,
-            .description = "F0 device",
+            .description = "F0xx",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,	// "Flash size data register" (pg735)
             .flash_pagesize = 0x400,		// Page sizes listed in Table 4
@@ -301,7 +301,7 @@ static const struct stlink_chipid_params devices[] = {
             // RM0402 document was used to find these parameters
             // Table 4.
             .chip_id = STLINK_CHIPID_STM32_F412,
-            .description = "F4 device",
+            .description = "F412",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1FFF7A22,   // "Flash size data register" (pg1135)
             .flash_pagesize = 0x4000,        // Table 5. Flash module organization ?
@@ -313,7 +313,7 @@ static const struct stlink_chipid_params devices[] = {
             // RM0430 DocID029473 Rev 2 document was used to find these parameters
             // Figure 2, Table 4, Table 5, Section 35.2
             .chip_id = STLINK_CHIPID_STM32_F413,
-            .description = "F4 device",
+            .description = "F413",
             .flash_type = STLINK_FLASH_TYPE_F4,
             .flash_size_reg = 0x1FFF7A22,   // "Flash size data register" Section 35.2
             .flash_pagesize = 0x4000,        // Table 5. Flash module organization (variable sector sizes, but 0x4000 is smallest)
@@ -323,7 +323,7 @@ static const struct stlink_chipid_params devices[] = {
         },
         {
             .chip_id = STLINK_CHIPID_STM32_F09X,
-            .description = "F09X device",
+            .description = "F09X",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,	// "Flash size data register" (pg735)
             .flash_pagesize = 0x800,		// Page sizes listed in Table 4 (pg 56)
@@ -335,7 +335,7 @@ static const struct stlink_chipid_params devices[] = {
             //Use this as an example for mapping future chips:
             //RM0091 document was used to find these paramaters
             .chip_id = STLINK_CHIPID_STM32_F04,
-            .description = "F04x device",
+            .description = "F04x",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,	// "Flash size data register" (pg735)
             .flash_pagesize = 0x400,		// Page sizes listed in Table 4
@@ -347,7 +347,7 @@ static const struct stlink_chipid_params devices[] = {
             //Use this as an example for mapping future chips:
             //RM0091 document was used to find these paramaters
             .chip_id = STLINK_CHIPID_STM32_F0_SMALL,
-            .description = "F0 small device",
+            .description = "F0xx small",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,	// "Flash size data register" (pg735)
             .flash_pagesize = 0x400,		// Page sizes listed in Table 4
@@ -358,7 +358,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             // STM32F30x
             .chip_id = STLINK_CHIPID_STM32_F3_SMALL,
-            .description = "F3 small device",
+            .description = "F3xx small",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,
             .flash_pagesize = 0x800,
@@ -370,7 +370,7 @@ static const struct stlink_chipid_params devices[] = {
             // STM32L0x
             // RM0367,RM0377 documents was used to find these parameters
             .chip_id = STLINK_CHIPID_STM32_L0,
-            .description = "L0x3 device",
+            .description = "L0x3",
             .flash_type = STLINK_FLASH_TYPE_L0,
             .flash_size_reg = 0x1ff8007c,
             .flash_pagesize = 0x80,
@@ -382,7 +382,7 @@ static const struct stlink_chipid_params devices[] = {
             // STM32L0x Category 5
             // RM0367,RM0377 documents was used to find these parameters
             .chip_id = STLINK_CHIPID_STM32_L0_CAT5,
-            .description = "L0x Category 5 device",
+            .description = "L0xx Category 5",
             .flash_type = STLINK_FLASH_TYPE_L0,
             .flash_size_reg = 0x1ff8007c,
             .flash_pagesize = 0x80,
@@ -394,7 +394,7 @@ static const struct stlink_chipid_params devices[] = {
             // STM32L0x Category 2
             // RM0367,RM0377 documents was used to find these parameters
             .chip_id = STLINK_CHIPID_STM32_L0_CAT2,
-            .description = "L0x Category 2 device",
+            .description = "L0xx Category 2",
             .flash_type = STLINK_FLASH_TYPE_L0,
             .flash_size_reg = 0x1ff8007c,
             .flash_pagesize = 0x80,
@@ -406,7 +406,7 @@ static const struct stlink_chipid_params devices[] = {
             // STM32F334, STM32F303x6/8, and STM32F328
             // From RM0364 and RM0316
             .chip_id = STLINK_CHIPID_STM32_F334,
-            .description = "F3xx medium density device", // (RM0316 sec 33.6.1)
+            .description = "F334 medium density", // (RM0316 sec 33.6.1)
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,
             .flash_pagesize = 0x800,
@@ -418,7 +418,7 @@ static const struct stlink_chipid_params devices[] = {
             // This is STK32F303RET6 device from STM32 F3 Nucelo board.
             // Support based on DM00043574.pdf (RM0316) document rev 5.
             .chip_id = STLINK_CHIPID_STM32_F303_HIGH,
-            .description = "F303 high density device",
+            .description = "F303 high density",
             .flash_type = STLINK_FLASH_TYPE_F0,
             .flash_size_reg = 0x1ffff7cc,    // 34.2.1 Flash size data register
             .flash_pagesize = 0x800,         // 4.2.1 Flash memory organization
@@ -430,7 +430,7 @@ static const struct stlink_chipid_params devices[] = {
             // STM32L4x6
             // From RM0351.
             .chip_id = STLINK_CHIPID_STM32_L4,
-            .description = "L4 device",
+            .description = "L4xx",
             .flash_type = STLINK_FLASH_TYPE_L4,
             .flash_size_reg = 0x1FFF75e0,    // "Flash size data register" (sec 45.2, page 1671)
             .flash_pagesize = 0x800,         // 2K (sec 3.2, page 78; also appears in sec 3.3.1 and tables 4-6 on pages 79-81)
@@ -445,7 +445,7 @@ static const struct stlink_chipid_params devices[] = {
             // STM32L4RX
             // From DM00310109.pdf
             .chip_id = STLINK_CHIPID_STM32_L4RX,
-            .description = "L4Rx device",
+            .description = "L4Rx",
             .flash_type = STLINK_FLASH_TYPE_L4,
             .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (sec 52.2, page 2049)
             .flash_pagesize = 0x1000,        // 4k, section 3.3, pg 97
@@ -457,7 +457,7 @@ static const struct stlink_chipid_params devices[] = {
             // STLINK_CHIPID_STM32_L41X
             // From RM0394 Rev 4 and DS12469 Rev 5
             .chip_id = STLINK_CHIPID_STM32_L41X,
-            .description = "L41x device",
+            .description = "L41x",
             .flash_type = STLINK_FLASH_TYPE_L4,
             .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (RM0394, sec 47.2, page 1586)
             .flash_pagesize = 0x800,         // 2K (DS12469, sec 3.4, page 17)
@@ -471,7 +471,7 @@ static const struct stlink_chipid_params devices[] = {
             // STLINK_CHIPID_STM32_L43X
             // From RM0392.
             .chip_id = STLINK_CHIPID_STM32_L43X,
-            .description = "L43x/L44x device",
+            .description = "L43x/L44x",
             .flash_type = STLINK_FLASH_TYPE_L4,
             .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (sec 43.2, page 1410)
             .flash_pagesize = 0x800,         // 2K (sec 3.2, page 74; also appears in sec 3.3.1 and tables 7-8 on pages 75-76)
@@ -486,7 +486,7 @@ static const struct stlink_chipid_params devices[] = {
             // STLINK_CHIPID_STM32_L496X
             // Support based on en.DM00083560.pdf (RM0351) document rev 5.
             .chip_id = STLINK_CHIPID_STM32_L496X,
-            .description = "L496x/L4A6x device",
+            .description = "L496x/L4A6x",
             .flash_type = STLINK_FLASH_TYPE_L4,
             .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (sec 49.2, page 1809)
             .flash_pagesize = 0x800,         // Page erase (2 Kbyte) (sec 3.2, page 93)
@@ -500,7 +500,7 @@ static const struct stlink_chipid_params devices[] = {
             // STLINK_CHIPID_STM32_L46X
             // From RM0394 (updated version of RM0392?).
             .chip_id = STLINK_CHIPID_STM32_L46X,
-            .description = "L45x/46x device",
+            .description = "L45x/46x",
             .flash_type = STLINK_FLASH_TYPE_L4,
             .flash_size_reg = 0x1fff75e0,    // "Flash size data register" (sec 45.2, page 1463)
             .flash_pagesize = 0x800,         // 2K (sec 3.2, page 73; also appears in sec 3.3.1 and tables 7 on pages 73-74)
@@ -513,7 +513,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             // STM32L011
             .chip_id = STLINK_CHIPID_STM32_L011,
-            .description = "L011 device",
+            .description = "L011",
             .flash_type = STLINK_FLASH_TYPE_L0,
             .flash_size_reg = 0x1ff8007c,
             .flash_pagesize = 0x80,
@@ -524,7 +524,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             // STM32GG030/031/041 (from RM0444)
             .chip_id = STLINK_CHIPID_STM32_G0_CAT1,
-            .description = "G030/G031/G041 device",
+            .description = "G030/G031/G041",
             .flash_type = STLINK_FLASH_TYPE_G0,
             .flash_size_reg = 0x1FFF75E0,    // Section 38.2
             .flash_pagesize = 0x800,         // 2K (sec 3.2)
@@ -535,7 +535,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             // STM32G071/081 (from RM0444)
             .chip_id = STLINK_CHIPID_STM32_G0_CAT2,
-            .description = "G070/G071/G081 device",
+            .description = "G070/G071/G081",
             .flash_type = STLINK_FLASH_TYPE_G0,
             .flash_size_reg = 0x1FFF75E0,    // Section 38.2
             .flash_pagesize = 0x800,         // 2K (sec 3.2)
@@ -546,7 +546,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             // STM32G431/441 (from RM0440)
             .chip_id = STLINK_CHIPID_STM32_G4_CAT2,
-            .description = "G4 Category-2 device",
+            .description = "G4 Category-2",
             .flash_type = STLINK_FLASH_TYPE_G4,
             .flash_size_reg = 0x1FFF75E0,    // Section 47.2
             .flash_pagesize = 0x800,         // 2K (sec 3.3.1)
@@ -557,7 +557,7 @@ static const struct stlink_chipid_params devices[] = {
         {
             // STM32WB55 (from RM0434)
             .chip_id = STLINK_CHIPID_STM32_WB55,
-            .description = "WB55 device",
+            .description = "WB55",
             .flash_type = STLINK_FLASH_TYPE_WB,
             .flash_size_reg = 0x1FFF75E0,
             .flash_pagesize = 0x1000, // 4K

--- a/src/common.c
+++ b/src/common.c
@@ -830,7 +830,9 @@ int stlink_cpu_id(stlink_t *sl, cortex_m3_cpuid_t *cpuid) {
  * @return 0 for success, or -1 for unsupported core type.
  */
 int stlink_load_device_params(stlink_t *sl) {
-    ILOG("Loading device parameters....\n");
+    // This seems to normally work so is unnecessary info for a normal
+    // user. Demoted to debug. -- REW
+    DLOG("Loading device parameters....\n");
     const struct stlink_chipid_params *params = NULL;
     stlink_core_id(sl);
     uint32_t chip_id;
@@ -894,11 +896,19 @@ int stlink_load_device_params(stlink_t *sl) {
         sl->sram_size = 0x1000;
     }
 
+#if 0
+    // Old code -- REW
     ILOG("Device connected is: %s, id %#x\n", params->description, chip_id);
     // TODO make note of variable page size here.....
     ILOG("SRAM size: %#x bytes (%d KiB), Flash: %#x bytes (%d KiB) in pages of %u bytes\n",
             sl->sram_size, sl->sram_size / 1024, sl->flash_size, sl->flash_size / 1024,
 	 (unsigned int)sl->flash_pgsz);
+#else
+    ILOG("%s: %d KiB SRAM, %d KiB flash in %d %s pages.\n", 
+	params->description, sl->sram_size / 1024, sl->flash_size / 1024, 
+	(sl->flash_pgsz < 1024)? sl->flash_pgsz  :  sl->flash_pgsz/1024, 
+        (sl->flash_pgsz < 1024)?  "byte"         :  "KiB");
+#endif
     return 0;
 }
 

--- a/src/gdbserver/gdb-server.c
+++ b/src/gdbserver/gdb-server.c
@@ -246,8 +246,9 @@ int main(int argc, char** argv) {
     }
 
 
-
-    ILOG("Chip ID is %08x, Core ID is  %08x.\n", sl->chip_id, sl->core_id);
+    // This is low-level information for debugging, not useful for normal use. 
+    // So: Demoted to a debug meesage. -- REW
+    DLOG("Chip ID is %08x, Core ID is  %08x.\n", sl->chip_id, sl->core_id);
 
     sl->verbose=0;
     current_memory_map = make_memory_map(sl);

--- a/src/usb.c
+++ b/src/usb.c
@@ -1049,7 +1049,9 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
     stlink_version(sl);
 
     if (stlink_current_mode(sl) == STLINK_DEV_DFU_MODE) {
-        ILOG("-- exit_dfu_mode\n");
+        // This seems to work, and is unnecessary information for the user.
+        // Demoted to debug -- REW
+        DLOG("-- exit_dfu_mode\n");
         stlink_exit_dfu_mode(sl);
     }
 


### PR DESCRIPTION
As requested. The startup of st-util is now: 
```
assurancetourix:~> ~/stm32/stlink.git2/build/Release/src/gdbserver/st-util -m
st-util 1.6.0-33-gb8813fa-dirty
2020-03-21T16:07:15 INFO common.c: F0xx small: 4 KiB SRAM, 16 KiB flash in 1 KiB pages.
2020-03-21T16:07:15 INFO gdb-server.c: Listening at *:4242...

```
The user may want the "listening at" message and the "what's connected" message has been reduced from two lines to just one. It now contains just the info that normal users may want to know.: stuff that helps determine if say the right target is connected. 

I removed all the "device" parts of the strings in the description of the chipID table. 
Some of the "description" entries in the table had a check for say a CHIPID_F412 and then proceded to call the device an F4xx. Lets just call it F412 then. But maybe there are other devices that share the same chipID let me know if you find one. 