### PR TITLE
Error return in failed probe (Fixes #887)

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -1069,14 +1069,16 @@ stlink_t *stlink_open_usb(enum ugly_loglevel verbose, bool reset, char serial[ST
     }
 
     ret = stlink_load_device_params(sl);
+    if (ret == -1) {
+        // This one didn't have any message. 
+        goto on_libusb_error;
+    }
+    return sl;
 
 on_libusb_error:
-    if (ret == -1) {
-        stlink_close(sl);
-        return NULL;
-    }
+    stlink_close(sl);
+    return NULL;
 
-    return sl;
 
 on_error:
     if (slu->libusb_ctx)


### PR DESCRIPTION
Separate pull request for separate issue. On error in probe, the 1.6 version did not error out. This seems due to wanting to save a couple of lines that didn't work out. I added the two necessary lines. 