### PR TITLE
Fix int length issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: "[Your device name]: [Title]"
+labels: bug/needs-investigation
+assignees: ''
+
+---
+
+Thank you for giving feedback to the stlink project.
+
+In order to allow developers and other contributors to isolate and target your respective issue, please take some time to fill out each of the following items appropriate to your specific problem:
+
+- Programmer/board type: [enter here] (e.g Stlink /v1, /v2, /v2-clone, /v2-1)
+- Programmer firmware version: [enter here] (e.g STSW-LINK007 2.27.15)
+- Operating system and version: [enter here] (e.g Linux, Mac OS X, Windows)
+- **Stlink tools version** and/or git commit hash: [enter here] (e.g v1.1.0/git-c722056)
+- Stlink commandline tool name: [enter here] (e.g `st-info`, `st-flash`, `st-util`)
+- Target chip (and board if applicable): [enter here] (e.g STM32F402VG)
+
+Futher we kindly ask you to describe the detected problem as detailed as possible and to add debug output if available, by using the following template:
+
+Commandline-Output:
+
+```
+OUTPUT/ERROR of the commandline tool(s)
+```
+
+Expected/description:
+
+`short description of the expected value`
+
+
+**NOTICE: This bug report may be closed without further notice, if not enough information is provided!**
+
+Thank you for your support.
+
+The stlink project maintainers

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,39 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[feature] "
+labels: code/feature-request
+assignees: ''
+
+---
+
+Thank you for giving feedback to the stlink project.
+
+In order to allow developers and other contributors to isolate and target your respective issue, please take some time to fill out the check boxes below by setting a 'x' into the checkboxes ( [x] ) and edit each item appropriate to your specific problem.
+
+- [ ] Programmer/board type: e.g Stlink/v1, Stlink/v2, Stlink/v2-onboard
+- [ ] Programmer firmware version: e.g STSW-LINK007 2.27.15
+- [ ] Operating system: e.g Linux, Mac OS X, Windows (with specific version)
+- [ ] Stlink tools version and/or git commit hash: e.g v1.1.0/git-c722056
+- [ ] Stlink commandline tool name: e.g `st-info`, `st-flash`, `st-util`
+- [ ] Target chip (and optional board): e.g STM32F402VG (STM32Fxxx Discovery)
+
+Futher we kindly ask you to describe the detected problem as detailled as possible and to add debug output if available, by using the following template:
+
+Commandline-Output:
+
+```
+OUTPUT/ERROR of the commandline tool(s)
+```
+
+Expected/description:
+
+`short description of the expected value`
+
+
+**NOTICE: This feature request may be closed without notice when not enough information is provided!**
+
+
+Thank you for your support.
+
+The stlink project maintainers

--- a/src/common.c
+++ b/src/common.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #include <errno.h>
 #include <unistd.h>
@@ -1257,8 +1258,14 @@ static int map_file(mapped_file_t* mf, const char* path) {
         fprintf(stderr, "fstat() == -1\n");
         goto on_error;
     }
-
-    mf->base = (uint8_t*) mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
+    if (sizeof(st.st_size) != sizeof(size_t)) {
+        /* On 32 bit systems, check if there is an overflow */
+        if (st.st_size > (off_t)UINT32_MAX) {
+            fprintf(stderr, "mmap() size_t overflow\n");
+            goto on_error;
+        }
+    }
+    mf->base = (uint8_t*) mmap(NULL, (size_t)(st.st_size), PROT_READ, MAP_SHARED, fd, 0);
     if (mf->base == MAP_FAILED) {
         fprintf(stderr, "mmap() == MAP_FAILED\n");
         goto on_error;

--- a/src/usb.c
+++ b/src/usb.c
@@ -189,7 +189,7 @@ int _stlink_usb_version(stlink_t *sl) {
         cmd[i++] = STLINK_APIV3_GET_VERSION_EX;
 
         size = send_recv(slu, 1, cmd, slu->cmd_len, data, rep_len);
-        if (size != rep_len) {
+        if (size != (ssize_t)rep_len) {
             printf("[!] send_recv STLINK_APIV3_GET_VERSION_EX\n");
             return (int) size;
         }


### PR DESCRIPTION
Make stlink build on 32 bit systems.

Build passed on ubuntu 16.04 i386 and macOS Mojave 10.14.6 AMD64.

`make test` failed for flash, which seems to be the same as current master.

Related issue:

[https://github.com/texane/stlink/issues/629](https://github.com/texane/stlink/issues/629)