### PR TITLE
stm32gx improvements

### DIFF
--- a/include/stlink.h
+++ b/include/stlink.h
@@ -159,6 +159,8 @@ typedef struct flash_loader {
         int serial_size;
 
         enum stlink_flash_type flash_type;	// stlink_chipid_params.flash_type, set by stlink_load_device_params(), values: STLINK_FLASH_TYPE_xxx
+        bool has_dual_bank;
+
         stm32_addr_t flash_base;	// STM32_FLASH_BASE, set by stlink_load_device_params()
         size_t flash_size;	// calculated by stlink_load_device_params()
         size_t flash_pgsz;	// stlink_chipid_params.flash_pagesize, set by stlink_load_device_params()

--- a/include/stlink/chipid.h
+++ b/include/stlink/chipid.h
@@ -73,6 +73,7 @@ struct stlink_chipid_params {
 	uint32_t chip_id;
 	char *description;
 	enum stlink_flash_type flash_type;
+	bool has_dual_bank;
 	uint32_t flash_size_reg;
 	uint32_t flash_pagesize;
 	uint32_t sram_size;

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -562,6 +562,7 @@ static const struct stlink_chipid_params devices[] = {
             .chip_id = STLINK_CHIPID_STM32_G4_CAT3,
             .description = "G4 Category-3",
             .flash_type = STLINK_FLASH_TYPE_G4,
+            .has_dual_bank = true,
             .flash_size_reg = 0x1FFF75E0,    // Section 47.2
             .flash_pagesize = 0x800,         // 2K (sec 3.3.1)
             // SRAM1 is 80k at 0x20000000

--- a/src/common.c
+++ b/src/common.c
@@ -128,8 +128,12 @@
 #define STM32Gx_FLASH_CR_OBL_LAUNCH (27)      /* Forces the option byte loading */
 #define STM32Gx_FLASH_CR_OPTLOCK    (30)      /* Options Lock */
 #define STM32Gx_FLASH_CR_LOCK       (31)      /* FLASH_CR Lock */
+
 // G0/G4 FLASH status register
 #define STM32Gx_FLASH_SR_BSY        (16)      /* FLASH_SR Busy */
+
+// G4 FLASH option register
+#define STM32G4_FLASH_OPTR_DBANK    (22)      /* FLASH_OPTR Dual Bank Mode */
 
 // WB (RM0434)
 #define STM32WB_FLASH_REGS_ADDR ((uint32_t)0x58004000)
@@ -897,6 +901,14 @@ int stlink_load_device_params(stlink_t *sl) {
     //STM32F100xx datasheet Doc ID 16455 Table 2
     if(sl->chip_id == STLINK_CHIPID_STM32_F1_VL_MEDIUM_LOW && sl->flash_size < 64 * 1024){
         sl->sram_size = 0x1000;
+    }
+
+    if (sl->chip_id == STLINK_CHIPID_STM32_G4_CAT3) {
+        uint32_t flash_optr;
+        stlink_read_debug32(sl, STM32Gx_FLASH_OPTR, &flash_optr);
+        if (!(flash_optr & (1 << STM32G4_FLASH_OPTR_DBANK))) {
+            sl->flash_pgsz <<= 1;
+        }
     }
 
 #if 0

--- a/src/common.c
+++ b/src/common.c
@@ -1980,7 +1980,6 @@ int stlink_erase_flash_mass(stlink_t *sl) {
     /* TODO: User MER bit to mass-erase G0, G4, WB series. */
     if (sl->flash_type == STLINK_FLASH_TYPE_L0 ||
         sl->flash_type == STLINK_FLASH_TYPE_G0 ||
-        sl->flash_type == STLINK_FLASH_TYPE_G4 ||
         sl->flash_type == STLINK_FLASH_TYPE_WB) {
         /* erase each page */
         int i = 0, num_pages = (int) sl->flash_size/sl->flash_pgsz;

--- a/src/common.c
+++ b/src/common.c
@@ -120,6 +120,7 @@
 #define STM32Gx_FLASH_CR_PNB         (3)      /* Page number */
 #define STM32G0_FLASH_CR_PNG_LEN     (5)      /* STM32G0: 5 page number bits */
 #define STM32G4_FLASH_CR_PNG_LEN     (7)      /* STM32G4: 7 page number bits */
+#define STM32Gx_FLASH_CR_MER2       (15)      /* Mass erase (2nd bank)*/
 #define STM32Gx_FLASH_CR_STRT       (16)      /* Start */
 #define STM32Gx_FLASH_CR_OPTSTRT    (17)      /* Start of modification of option bytes */
 #define STM32Gx_FLASH_CR_FSTPG      (18)      /* Fast programming */
@@ -519,7 +520,10 @@ static void set_flash_cr_mer(stlink_t *sl, bool v) {
     } else if (sl->flash_type == STLINK_FLASH_TYPE_G0 ||
                sl->flash_type == STLINK_FLASH_TYPE_G4) {
         cr_reg = STM32Gx_FLASH_CR;
-        cr_mer = (1 << FLASH_CR_MER);
+        cr_mer = (1 <<  STM32Gx_FLASH_CR_MER1);
+        if (sl->has_dual_bank) {
+			cr_mer |= (1 << STM32Gx_FLASH_CR_MER2);
+		}
         cr_pg  = (1 << FLASH_CR_PG);
     } else if (sl->flash_type == STLINK_FLASH_TYPE_WB) {
         cr_reg = STM32WB_FLASH_CR;

--- a/src/common.c
+++ b/src/common.c
@@ -885,7 +885,9 @@ int stlink_load_device_params(stlink_t *sl) {
     } else {
         sl->flash_size = flash_size * 1024;
     }
+
     sl->flash_type = params->flash_type;
+    sl->has_dual_bank = params->has_dual_bank;
     sl->flash_pgsz = params->flash_pagesize;
     sl->sram_size = params->sram_size;
     sl->sys_base = params->bootrom_base;

--- a/src/common.c
+++ b/src/common.c
@@ -1997,7 +1997,6 @@ int stlink_erase_flash_page(stlink_t *sl, stm32_addr_t flashaddr)
 int stlink_erase_flash_mass(stlink_t *sl) {
     /* TODO: User MER bit to mass-erase G0, G4, WB series. */
     if (sl->flash_type == STLINK_FLASH_TYPE_L0 ||
-        sl->flash_type == STLINK_FLASH_TYPE_G0 ||
         sl->flash_type == STLINK_FLASH_TYPE_WB) {
         /* erase each page */
         int i = 0, num_pages = (int) sl->flash_size/sl->flash_pgsz;


### PR DESCRIPTION
Hi,

here are a few patches to improve g4/g0 support
 - introduce a helper to handle devices with dual bank flash
 - handle cat3 g4 devices with configurable dual bank flash
 - enable mass erase for g4 and g0 devices. 
 - add a flash programming check at the end of mass erase.

has_dual bank flag could probably avoid multiple device type check around the code with a bit of work. 
flash programming check could probably be added in page erase and flash write and extended to other devices, to debug some silent issues.